### PR TITLE
ACC MM telemetry skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,21 @@
 # RaceDirector
 
 At the moment the software is a replacement for RaceRoom's closed source
-[Dash](https://github.com/sector3studios/webhud/blob/master/dist/dash.zip)
-command.
+[Dash](https://github.com/sector3studios/webhud/blob/master/dist/dash.zip) command. The major
+difference is that it can export telemetry from other games (see [supported games](docs/Games.md)).
 
-It is a console application that will read every 15ms the memory mapped file that
-RaceRoom exposes, only when the game is running. It will then expose that data on
-a WebSocket (`ws://localhost:8070/r3e`). The supported fields are those required
-by [RaceRoom's WebHud](https://github.com/sector3studios/webhud), and can be found
+It is a console application that will read every 15ms the memory mapped file that RaceRoom exposes,
+only when the game is running. It will then expose that data on a WebSocket
+(`ws://localhost:8070/r3e`). The supported fields are those required by
+[RaceRoom's WebHud](https://github.com/sector3studios/webhud), and can be found
 [here](docs/Plugins/HUD/README.md).
 
-To see it in action, RaceRoom can be configured to use the WebHud or a Web Browser
-window can be pointed to https://sector3studios.github.io/webhud/dist/.
+To see it in action, RaceRoom can be configured to use the WebHud or a Web Browser window can be
+pointed to https://sector3studios.github.io/webhud/dist/.
 
-Please note that [OtterHUD](https://forum.sector3studios.com/index.php?threads/otterhud-a-custom-webhud-with-additional-features.13152/) (closed source) requires more fields than *currently* supported.
+Please note that
+[OtterHUD](https://forum.sector3studios.com/index.php?threads/otterhud-a-custom-webhud-with-additional-features.13152/)
+(closed source) requires more fields than *currently* supported.
 
 ## Build
 

--- a/docs/Games.md
+++ b/docs/Games.md
@@ -2,162 +2,164 @@
 
 ## Telemetry
 
-| Field | R3E |
-| --- | --- |
-| GameState | ✓ |
-| UsingVR | ✓ |
-| Event.Track.SectorsEnd | ✓ |
-| Event.FuelRate | ✓ |
-| Session.Type | ✓ |
-| Session.Phase | ✓ |
-| Session.Length | ✓ |
-| Session.Requirements.MandatoryPitStops | ✓ |
-| Session.Requirements.MandatoryPitRequirements | |
-| Session.Requirements.PitWindow | ✓ |
-| Session.PitSpeedLimit | ✓ |
-| Session.PitLaneOpen | ✓ |
-| Session.ElapsedTime | ✓ |
-| Session.TimeRemaining | ✓ |
-| Session.WaitTime | ✓ |
-| Session.StartLights.Colour | ✓ |
-| Session.StartLights.Lit | ✓ |
-| Session.BestLap | |
-| Session.BestSectors.Individual | |
-| Session.BestSectors.Cumulative | |
-| Session.Flags.Track | |
-| Session.Flags.Sectors | ✓ |
-| Session.Flags.Leader | |
-| Vehicles[].Id | ✓ |
-| Vehicles[].ClassPerformanceIndex | ✓ |
-| Vehicles[].RacingStatus | ✓ |
-| Vehicles[].EngineType | |
-| Vehicles[].ControlType | |
-| Vehicles[].Position | |
-| Vehicles[].PositionClass | ✓ |
-| Vehicles[].GapAhead | ✓ |
-| Vehicles[].GapBehind | ✓ |
-| Vehicles[].CompletedLaps | ✓ |
-| Vehicles[].LapValid | ✓ |
-| Vehicles[].CurrentLapTime.Overall | |
-| Vehicles[].CurrentLapTime.Sectors.Individual | |
-| Vehicles[].CurrentLapTime.Sectors.Cumulative | |
-| Vehicles[].PreviousLapTime | |
-| Vehicles[].BestLapTime.Overall | |
-| Vehicles[].BestLapTime.Sectors.Individual | |
-| Vehicles[].BestLapTime.Sectors.Cumulative | |
-| Vehicles[].BestSectors | |
-| Vehicles[].CurrentLapDistance | ✓ |
-| Vehicles[].Location | ✓ |
-| Vehicles[].Orientation | |
-| Vehicles[].Speed | |
-| Vehicles[].CurrentDriver.Name | Partial |
-| Vehicles[].Pit.StopsDone | ✓ |
-| Vehicles[].Pit.MandatoryStopsDone | ✓ |
-| Vehicles[].Pit.PitLanePhase | |
-| Vehicles[].Pit.PitLaneTime | |
-| Vehicles[].Pit.PitStallTime | |
-| Vehicles[].Penalties | |
-| Vehicles[].Flags.Green | ✗ |
-| Vehicles[].Flags.Blue | ✗ |
-| Vehicles[].Flags.Yellow | ✗ |
-| Vehicles[].Flags.White | ✗ |
-| Vehicles[].Flags.Chequered | ✗ |
-| Vehicles[].Flags.Black | ✗ |
-| Vehicles[].Flags.BlackWhite | ✗ |
-| FocusedVehicle.Id | ✓ |
-| FocusedVehicle.ClassPerformanceIndex | ✓ |
-| FocusedVehicle.RacingStatus | ✓ |
-| FocusedVehicle.EngineType | ✓ |
-| FocusedVehicle.ControlType | ✓ |
-| FocusedVehicle.Position | |
-| FocusedVehicle.PositionClass | ✓ |
-| FocusedVehicle.GapAhead | |
-| FocusedVehicle.GapBehind | |
-| FocusedVehicle.CompletedLaps | ✓ |
-| FocusedVehicle.LapValid | ✓ |
-| FocusedVehicle.CurrentLapTime.Overall | ✓ |
-| FocusedVehicle.CurrentLapTime.Sectors.Individual
-| FocusedVehicle.CurrentLapTime.Sectors.Cumulative | ✓ |
-| FocusedVehicle.PreviousLapTime | |
-| FocusedVehicle.BestLapTime.Overall | ✓ |
-| FocusedVehicle.BestLapTime.Sectors.Individual
-| FocusedVehicle.BestLapTime.Sectors.Cumulative | ✓ |
-| FocusedVehicle.BestSectors | |
-| FocusedVehicle.CurrentLapDistance | ✓ |
-| FocusedVehicle.Location | ✓ |
-| FocusedVehicle.Orientation | ✓ |
-| FocusedVehicle.Speed | ✓ |
-| FocusedVehicle.CurrentDriver.Name | ✓ |
-| FocusedVehicle.Pit.StopsDone | ✓ |
-| FocusedVehicle.Pit.MandatoryStopsDone | ✓ |
-| FocusedVehicle.Pit.PitLanePhase | ✓ |
-| FocusedVehicle.Pit.PitLaneTime | ✓ |
-| FocusedVehicle.Pit.PitStallTime | ✓ |
-| FocusedVehicle.Penalties | ✓ |
-| FocusedVehicle.Inputs.Throttle | ✓ |
-| FocusedVehicle.Inputs.Brake | ✓ |
-| FocusedVehicle.Inputs.Clutch | ✓ |
-| FocusedVehicle.Flags.Green | ✓ |
-| FocusedVehicle.Flags.Blue | ✓ |
-| FocusedVehicle.Flags.Yellow | ✓ |
-| FocusedVehicle.Flags.White | ✓ |
-| FocusedVehicle.Flags.Chequered | ✓ |
-| FocusedVehicle.Flags.Black | ✓ |
-| FocusedVehicle.Flags.BlackWhite | ✓ |
-| Player.RawInputs.Throttle | ✓ |
-| Player.RawInputs.Brake | ✓ |
-| Player.RawInputs.Clutch | ✓ |
-| Player.RawInputs.Steering | ✓ |
-| Player.RawInputs.SteerWheelRange | ✓ |
-| Player.DrivingAids.Abs | ✓ |
-| Player.DrivingAids.Tc | ✓ |
-| Player.DrivingAids.Esp | ✓ |
-| Player.DrivingAids.Countersteer | ✓ |
-| Player.DrivingAids.Cornering | ✓ |
-| Player.VehicleSettings.EngineMap | |
-| Player.VehicleSettings.EngineBrakeReduction | |
-| Player.VehicleDamage.AerodynamicsPercent | ✓ |
-| Player.VehicleDamage.EnginePercent | ✓ |
-| Player.VehicleDamage.SuspensionPercent | ✓ |
-| Player.VehicleDamage.TransmissionPercent | ✓ |
-| Player.Tyres[][].Dirt | ✓ |
-| Player.Tyres[][].Grip | ✓ |
-| Player.Tyres[][].Wear | ✓ |
-| Player.Tyres[][].Temperatures.CurrentTemperatures[][] | ✓ |
-| Player.Tyres[][].Temperatures.OptimalTemperature | ✓ |
-| Player.Tyres[][].Temperatures.ColdTemperature | ✓ |
-| Player.Tyres[][].Temperatures.HotTemperature | ✓ |
-| Player.Tyres[][].BrakeTemperatures.CurrentTemperature | ✓ |
-| Player.Tyres[][].BrakeTemperatures.OptimalTemperature | ✓ |
-| Player.Tyres[][].BrakeTemperatures.ColdTemperature | ✓ |
-| Player.Tyres[][].BrakeTemperatures.HotTemperature | ✓ |
-| Player.Fuel.Max | ✓ |
-| Player.Fuel.Left | ✓ |
-| Player.Fuel.PerLap | ✓ |
-| Player.Engine.Speed | ✓ |
-| Player.Engine.UpshiftSpeed | ✓ |
-| Player.Engine.MaxSpeed | ✓ |
-| Player.CgLocation | ✓ |
-| Player.Orientation | |
-| Player.LocalAcceleration | ✓ |
-| Player.ClassBestLap | |
-| Player.ClassBestSectors.Individual | ✓ |
-| Player.ClassBestSectors.Cumulative | |
-| Player.PersonalBestSectors.Individual | ✓ |
-| Player.PersonalBestSectors.Cumulative | |
-| Player.PersonalBestDelta | ✓ |
-| Player.Drs.Available | ✓ |
-| Player.Drs.Engaged | ✓ |
-| Player.Drs.ActivationsLeft.Value | ✓ |
-| Player.Drs.ActivationsLeft.Total | ✓ |
-| Player.PushToPass.Available | ✓ |
-| Player.PushToPass.Engaged | ✓ |
-| Player.PushToPass.ActivationsLeft.Value | ✓ |
-| Player.PushToPass.ActivationsLeft.Total | ✓ |
-| Player.PushToPass.EngagedTimeLeft | ✓ |
-| Player.PushToPass.WaitTimeLeft | ✓ |
-| Player.PitStop | ✓ |
-| Player.Warnings.IncidentPoints | |
-| Player.Warnings.BlueFlagWarnings | ✓ |
-| Player.Warnings.GiveBackPositions | ✓ |
-| Player.OvertakeAllowed | ✓ |
+| Field | R3E | ACC |
+| --- | --- | --- |
+| GameState | ✓ | ✓ [^approx] |
+| UsingVR | ✓ | ✗ |
+| Event.Track.SectorsEnd | ✓ | ✗ |
+| Event.FuelRate | ✓ | ✓ |
+| Session.Type | ✓ | ✓ |
+| Session.Phase | ✓ | ✗ |
+| Session.Length | ✓ |  |
+| Session.Requirements.MandatoryPitStops | ✓ |  |
+| Session.Requirements.MandatoryPitRequirements | |  |
+| Session.Requirements.PitWindow | ✓ |  |
+| Session.PitSpeedLimit | ✓ |  |
+| Session.PitLaneOpen | ✓ |  |
+| Session.ElapsedTime | ✓ |  |
+| Session.TimeRemaining | ✓ |  |
+| Session.WaitTime | ✓ |  |
+| Session.StartLights.Colour | ✓ |  |
+| Session.StartLights.Lit | ✓ |  |
+| Session.BestLap | |  |
+| Session.BestSectors.Individual | |  |
+| Session.BestSectors.Cumulative | |  |
+| Session.Flags.Track | |  |
+| Session.Flags.Sectors | ✓ |  |
+| Session.Flags.Leader | |  |
+| Vehicles[].Id | ✓ |  |
+| Vehicles[].ClassPerformanceIndex | ✓ |  |
+| Vehicles[].RacingStatus | ✓ |  |
+| Vehicles[].EngineType | |  |
+| Vehicles[].ControlType | |  |
+| Vehicles[].Position | |  |
+| Vehicles[].PositionClass | ✓ |  |
+| Vehicles[].GapAhead | ✓ |  |
+| Vehicles[].GapBehind | ✓ |  |
+| Vehicles[].CompletedLaps | ✓ |  |
+| Vehicles[].LapValid | ✓ |  |
+| Vehicles[].CurrentLapTime.Overall | |  |
+| Vehicles[].CurrentLapTime.Sectors.Individual | |  |
+| Vehicles[].CurrentLapTime.Sectors.Cumulative | |  |
+| Vehicles[].PreviousLapTime | |  |
+| Vehicles[].BestLapTime.Overall | |  |
+| Vehicles[].BestLapTime.Sectors.Individual | |  |
+| Vehicles[].BestLapTime.Sectors.Cumulative | |  |
+| Vehicles[].BestSectors | |  |
+| Vehicles[].CurrentLapDistance | ✓ |  |
+| Vehicles[].Location | ✓ |  |
+| Vehicles[].Orientation | |  |
+| Vehicles[].Speed | |  |
+| Vehicles[].CurrentDriver.Name | Partial |  |
+| Vehicles[].Pit.StopsDone | ✓ |  |
+| Vehicles[].Pit.MandatoryStopsDone | ✓ |  |
+| Vehicles[].Pit.PitLanePhase | |  |
+| Vehicles[].Pit.PitLaneTime | |  |
+| Vehicles[].Pit.PitStallTime | |  |
+| Vehicles[].Penalties | |  |
+| Vehicles[].Flags.Green | ✗ |  |
+| Vehicles[].Flags.Blue | ✗ |  |
+| Vehicles[].Flags.Yellow | ✗ |  |
+| Vehicles[].Flags.White | ✗ |  |
+| Vehicles[].Flags.Chequered | ✗ |  |
+| Vehicles[].Flags.Black | ✗ |  |
+| Vehicles[].Flags.BlackWhite | ✗ |  |
+| FocusedVehicle.Id | ✓ |  |
+| FocusedVehicle.ClassPerformanceIndex | ✓ |  |
+| FocusedVehicle.RacingStatus | ✓ |  |
+| FocusedVehicle.EngineType | ✓ |  |
+| FocusedVehicle.ControlType | ✓ |  |
+| FocusedVehicle.Position | |  |
+| FocusedVehicle.PositionClass | ✓ |  |
+| FocusedVehicle.GapAhead | |  |
+| FocusedVehicle.GapBehind | |  |
+| FocusedVehicle.CompletedLaps | ✓ |  |
+| FocusedVehicle.LapValid | ✓ |  |
+| FocusedVehicle.CurrentLapTime.Overall | ✓ |  |
+| FocusedVehicle.CurrentLapTime.Sectors.Individual  |
+| FocusedVehicle.CurrentLapTime.Sectors.Cumulative | ✓ |  |
+| FocusedVehicle.PreviousLapTime | |  |
+| FocusedVehicle.BestLapTime.Overall | ✓ |  |
+| FocusedVehicle.BestLapTime.Sectors.Individual  |
+| FocusedVehicle.BestLapTime.Sectors.Cumulative | ✓ |  |
+| FocusedVehicle.BestSectors | |  |
+| FocusedVehicle.CurrentLapDistance | ✓ |  |
+| FocusedVehicle.Location | ✓ |  |
+| FocusedVehicle.Orientation | ✓ |  |
+| FocusedVehicle.Speed | ✓ |  |
+| FocusedVehicle.CurrentDriver.Name | ✓ |  |
+| FocusedVehicle.Pit.StopsDone | ✓ |  |
+| FocusedVehicle.Pit.MandatoryStopsDone | ✓ |  |
+| FocusedVehicle.Pit.PitLanePhase | ✓ |  |
+| FocusedVehicle.Pit.PitLaneTime | ✓ |  |
+| FocusedVehicle.Pit.PitStallTime | ✓ |  |
+| FocusedVehicle.Penalties | ✓ |  |
+| FocusedVehicle.Inputs.Throttle | ✓ |  |
+| FocusedVehicle.Inputs.Brake | ✓ |  |
+| FocusedVehicle.Inputs.Clutch | ✓ |  |
+| FocusedVehicle.Flags.Green | ✓ |  |
+| FocusedVehicle.Flags.Blue | ✓ |  |
+| FocusedVehicle.Flags.Yellow | ✓ |  |
+| FocusedVehicle.Flags.White | ✓ |  |
+| FocusedVehicle.Flags.Chequered | ✓ |  |
+| FocusedVehicle.Flags.Black | ✓ |  |
+| FocusedVehicle.Flags.BlackWhite | ✓ |  |
+| Player.RawInputs.Throttle | ✓ |  |
+| Player.RawInputs.Brake | ✓ |  |
+| Player.RawInputs.Clutch | ✓ |  |
+| Player.RawInputs.Steering | ✓ |  |
+| Player.RawInputs.SteerWheelRange | ✓ |  |
+| Player.DrivingAids.Abs | ✓ |  |
+| Player.DrivingAids.Tc | ✓ |  |
+| Player.DrivingAids.Esp | ✓ |  |
+| Player.DrivingAids.Countersteer | ✓ |  |
+| Player.DrivingAids.Cornering | ✓ |  |
+| Player.VehicleSettings.EngineMap | |  |
+| Player.VehicleSettings.EngineBrakeReduction | |  |
+| Player.VehicleDamage.AerodynamicsPercent | ✓ |  |
+| Player.VehicleDamage.EnginePercent | ✓ |  |
+| Player.VehicleDamage.SuspensionPercent | ✓ |  |
+| Player.VehicleDamage.TransmissionPercent | ✓ |  |
+| Player.Tyres[][].Dirt | ✓ |  |
+| Player.Tyres[][].Grip | ✓ |  |
+| Player.Tyres[][].Wear | ✓ |  |
+| Player.Tyres[][].Temperatures.CurrentTemperatures[][] | ✓ |  |
+| Player.Tyres[][].Temperatures.OptimalTemperature | ✓ |  |
+| Player.Tyres[][].Temperatures.ColdTemperature | ✓ |  |
+| Player.Tyres[][].Temperatures.HotTemperature | ✓ |  |
+| Player.Tyres[][].BrakeTemperatures.CurrentTemperature | ✓ |  |
+| Player.Tyres[][].BrakeTemperatures.OptimalTemperature | ✓ |  |
+| Player.Tyres[][].BrakeTemperatures.ColdTemperature | ✓ |  |
+| Player.Tyres[][].BrakeTemperatures.HotTemperature | ✓ |  |
+| Player.Fuel.Max | ✓ |  |
+| Player.Fuel.Left | ✓ |  |
+| Player.Fuel.PerLap | ✓ |  |
+| Player.Engine.Speed | ✓ |  |
+| Player.Engine.UpshiftSpeed | ✓ |  |
+| Player.Engine.MaxSpeed | ✓ |  |
+| Player.CgLocation | ✓ |  |
+| Player.Orientation | |  |
+| Player.LocalAcceleration | ✓ |  |
+| Player.ClassBestLap | |  |
+| Player.ClassBestSectors.Individual | ✓ |  |
+| Player.ClassBestSectors.Cumulative | |  |
+| Player.PersonalBestSectors.Individual | ✓ |  |
+| Player.PersonalBestSectors.Cumulative | |  |
+| Player.PersonalBestDelta | ✓ |  |
+| Player.Drs.Available | ✓ |  |
+| Player.Drs.Engaged | ✓ |  |
+| Player.Drs.ActivationsLeft.Value | ✓ |  |
+| Player.Drs.ActivationsLeft.Total | ✓ |  |
+| Player.PushToPass.Available | ✓ |  |
+| Player.PushToPass.Engaged | ✓ |  |
+| Player.PushToPass.ActivationsLeft.Value | ✓ |  |
+| Player.PushToPass.ActivationsLeft.Total | ✓ |  |
+| Player.PushToPass.EngagedTimeLeft | ✓ |  |
+| Player.PushToPass.WaitTimeLeft | ✓ |  |
+| Player.PitStop | ✓ |  |
+| Player.Warnings.IncidentPoints | |  |
+| Player.Warnings.BlueFlagWarnings | ✓ |  |
+| Player.Warnings.GiveBackPositions | ✓ |  |
+| Player.OvertakeAllowed | ✓ |  |
+
+[^approx]: Approximated

--- a/docs/Plugins/HUD/README.md
+++ b/docs/Plugins/HUD/README.md
@@ -12,7 +12,7 @@ It is an alternative to [RaceRoom's Dash](https://github.com/sector3studios/webh
 | VersionMinor | ✓ |
 | AllDriversOffset | |
 | DriverDataSize | |
-| GamePaused | |
+| GamePaused | ✓ |
 | GameInMenus | ✓ |
 | GameInReplay | ✓ |
 | GameUsingVr | ✓ |

--- a/src/Plugins/HUD/Pipeline/R3EDashTransformer.cs
+++ b/src/Plugins/HUD/Pipeline/R3EDashTransformer.cs
@@ -41,8 +41,7 @@ namespace RaceDirector.Plugin.HUD.Pipeline
                 // AllDriversOffset
                 // DriverDataSize
 
-                // GamePaused
-
+                w.WriteNumber("GamePaused", gt.Session is null ? -1 : MatchAsInt32(gt.GameState, GameState.Paused));
                 w.WriteNumber("GameInMenus", gt.Session is null ? -1 : MatchAsInt32(gt.GameState, GameState.Menu));
                 w.WriteNumber("GameInReplay", gt.Session is null ? -1 : MatchAsInt32(gt.GameState, GameState.Replay));
                 w.WriteNumber("GameUsingVr", gt.Session is null ? -1 : ToInt32(gt.UsingVR));

--- a/src/Plugins/HUD/Pipeline/R3EDashTransformer.cs
+++ b/src/Plugins/HUD/Pipeline/R3EDashTransformer.cs
@@ -122,9 +122,9 @@ namespace RaceDirector.Plugin.HUD.Pipeline
                 // TrackId
                 // LayoutId
 
-                w.WriteRoundedNumber("LayoutLength", (gt.Event?.Track.Length?.M) ?? -1.0);
+                w.WriteRoundedNumber("LayoutLength", (gt.Event?.TrackLayout.Length?.M) ?? -1.0);
 
-                w.WriteSectors("SectorStartFactors", gt.Event?.Track.SectorsEnd, st => st.Fraction);
+                w.WriteSectors("SectorStartFactors", gt.Event?.TrackLayout.SectorsEnd, st => st.Fraction);
 
                 // RaceSessionLaps.Race1
                 // RaceSessionLaps.Race2
@@ -310,7 +310,8 @@ namespace RaceDirector.Plugin.HUD.Pipeline
                 // NumPenalties
 
                 w.WriteNumber("CompletedLaps", ToInt32(gt.FocusedVehicle?.CompletedLaps));
-                w.WriteNumber("CurrentLapValid", gt.FocusedVehicle?.LapValid switch {
+                w.WriteNumber("CurrentLapValid", gt.FocusedVehicle?.LapValid switch
+                {
                     LapValidState.Invalid => 0,
                     LapValidState.Valid => 1,
                     _ => -1
@@ -368,7 +369,8 @@ namespace RaceDirector.Plugin.HUD.Pipeline
 
                     w.WriteNumber("SlotId", ToInt32(gt.FocusedVehicle?.Id));
                     w.WriteNumber("ClassPerformanceIndex", gt.FocusedVehicle?.ClassPerformanceIndex ?? -1);
-                    w.WriteNumber("EngineType", gt.FocusedVehicle?.EngineType switch {
+                    w.WriteNumber("EngineType", gt.FocusedVehicle?.EngineType switch
+                    {
                         EngineType.Combustion => 0,
                         EngineType.Electric => 1,
                         EngineType.Hybrid => 2,

--- a/src/RaceDirector.Interface/Pipeline/Telemetry/GameTelemetry.cs
+++ b/src/RaceDirector.Interface/Pipeline/Telemetry/GameTelemetry.cs
@@ -28,12 +28,12 @@ namespace RaceDirector.Pipeline.Telemetry
 
     public record Event
     (
-        TrackLayout Track,
+        TrackLayout TrackLayout,
         // ISessionDuration[] SessionsLength
         double FuelRate
     ) : IEvent
     {
-        ITrackLayout IEvent.Track => Track;
+        ITrackLayout IEvent.TrackLayout => TrackLayout;
     }
 
     public record TrackLayout

--- a/src/RaceDirector.Interface/Pipeline/Telemetry/GameTelemetry.cs
+++ b/src/RaceDirector.Interface/Pipeline/Telemetry/GameTelemetry.cs
@@ -11,7 +11,7 @@ namespace RaceDirector.Pipeline.Telemetry
     public record GameTelemetry
     (
         GameState GameState,
-        bool UsingVR,
+        bool? UsingVR,
         Event? Event,
         Session? Session,
         Vehicle[] Vehicles,

--- a/src/RaceDirector.Interface/Pipeline/Telemetry/IGameTelemetry.cs
+++ b/src/RaceDirector.Interface/Pipeline/Telemetry/IGameTelemetry.cs
@@ -170,6 +170,7 @@ namespace RaceDirector.Pipeline.Telemetry
 
         public enum SessionPhase
         {
+            Unknown = 0,
             Garage = 1,           // R3E, RF2
             GridWalk = 2,         // R3E, RF2
             Formation = 3,        // R3E, AMS2 (eSessionState), RF2

--- a/src/RaceDirector.Interface/Pipeline/Telemetry/IGameTelemetry.cs
+++ b/src/RaceDirector.Interface/Pipeline/Telemetry/IGameTelemetry.cs
@@ -64,7 +64,7 @@ namespace RaceDirector.Pipeline.Telemetry
         public enum GameState
         {
             Driving,
-            //Paused,  // R3E GamePaused - is the clock ticking? (-1 in main menu, 0 in replay, 1 in single player menu, 0 in multi player menu)
+            Paused,  // R3E GamePaused - is the clock ticking? (-1 in main menu, 0 in replay, 1 in single player menu, 0 in multi player menu)
             Menu,    // R3E GameInMenus (-1 in main menu, 1 in single or multi player menu, 1 in monitor)
             Replay   // R3E GameInReplay (-1 in main menu, 1 in replay, 0 in monitor)
         }

--- a/src/RaceDirector.Interface/Pipeline/Telemetry/IGameTelemetry.cs
+++ b/src/RaceDirector.Interface/Pipeline/Telemetry/IGameTelemetry.cs
@@ -71,7 +71,7 @@ namespace RaceDirector.Pipeline.Telemetry
 
         public interface IEvent
         {
-            ITrackLayout Track { get; }
+            ITrackLayout TrackLayout { get; }
 
             /// <summary>
             /// Fuel burning rate. 0.0 disabled, 1.0 is normal, 2.0 double, etc.

--- a/src/RaceDirector.Interface/Pipeline/Telemetry/IGameTelemetry.cs
+++ b/src/RaceDirector.Interface/Pipeline/Telemetry/IGameTelemetry.cs
@@ -23,7 +23,7 @@ namespace RaceDirector.Pipeline.Telemetry
         {
             GameState GameState { get; }
 
-            bool UsingVR { get; }
+            bool? UsingVR { get; }
 
             /// <summary>
             /// Race event information.

--- a/src/RaceDirector/Pipeline/Games/ACC/Contrib.cs
+++ b/src/RaceDirector/Pipeline/Games/ACC/Contrib.cs
@@ -105,14 +105,6 @@ namespace RaceDirector.Pipeline.Games.ACC.Contrib
             Pause = 3
         }
 
-        public enum WheelsType
-        {
-            FrontLeft = 0,
-            FrontRight = 1,
-            RearLeft = 2,
-            RearRight = 3
-        }
-
         public enum TrackGripStatus
         {
             Green = 0,
@@ -137,6 +129,11 @@ namespace RaceDirector.Pipeline.Games.ACC.Contrib
 
     namespace Data
     {
+        public struct Shared {
+            public SPageFilePhysics Physics;
+            public SPageFileGraphic Graphic;
+            public SPageFileStatic Static;
+        }
 
         /// <summary>
         /// The following members change at each graphic step. They all refer to
@@ -352,6 +349,7 @@ namespace RaceDirector.Pipeline.Games.ACC.Contrib
             public int NumCars; // Number of cars
             [MarshalAsAttribute(UnmanagedType.ByValTStr, SizeConst = 33)]
             public string CarModel; // Player car model see Appendix 2
+            [MarshalAsAttribute(UnmanagedType.ByValTStr, SizeConst = 33)]
             public string Track; // Track name
             [MarshalAsAttribute(UnmanagedType.ByValTStr, SizeConst = 33)]
             public string PlayerName; // Player name

--- a/src/RaceDirector/Pipeline/Games/ACC/Contrib.cs
+++ b/src/RaceDirector/Pipeline/Games/ACC/Contrib.cs
@@ -396,8 +396,6 @@ namespace RaceDirector.Pipeline.Games.ACC.Contrib
             public string DryTyresName; // Name of the dry tyres
             [MarshalAsAttribute(UnmanagedType.ByValTStr, SizeConst = 33)]
             public string WetTyresName; // Name of the wet tyres
-
-            public int SmVersionMajor => Int32.Parse(SmVersion.Split('.')[0]);
         }
 
         [StructLayout(LayoutKind.Sequential, Pack = 4)]

--- a/src/RaceDirector/Pipeline/Games/ACC/Contrib.cs
+++ b/src/RaceDirector/Pipeline/Games/ACC/Contrib.cs
@@ -1,0 +1,443 @@
+﻿//////////////////////////////////////////////////////////////////////////
+// Based on the official documentation from Kunos
+// https://www.assettocorsa.net/forum/index.php?threads/acc-shared-memory-documentation.59965/
+// 
+// This is free and unencumbered software released into the public domain.
+// 
+// Anyone is free to copy, modify, publish, use, compile, sell, or
+// distribute this software, either in source code form or as a compiled
+// binary, for any purpose, commercial or non-commercial, and by any
+// means.
+// 
+// In jurisdictions that recognize copyright laws, the author or authors
+// of this software dedicate any and all copyright interest in the
+// software to the public domain.We make this dedication for the benefit
+// of the public at large and to the detriment of our heirs and
+// successors.We intend this dedication to be an overt act of
+// relinquishment in perpetuity of all present and future rights to this
+// software under copyright law.
+// 
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+// 
+// For more information, please refer to<http://unlicense.org>
+// 
+//////////////////////////////////////////////////////////////////////////
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace RaceDirector.Pipeline.Games.ACC.Contrib
+{
+    public static class Constant
+    {
+        public const string SharedMemoryPhysicsName = "Local\\acpmf_physics";
+        public const string SharedMemoryGraphicName = "Local\\acpmf_graphics";
+        public const string SharedMemoryStaticName = "Local\\acpmf_static";
+
+        public const int SmVersionMajor = 1;
+        public const int SmVersionMinor = 9;
+
+        public enum FlagType
+        {
+            NoFlag = 0,
+            BlueFlag = 1,
+            YellowFlag = 2,
+            BlackFlag = 3,
+            WhiteFlag = 4,
+            CheckeredFlag = 5,
+            PenaltyFlag = 6,
+            GreenFlag = 7,
+            OrangeFlag = 8
+        }
+
+        public enum PenaltyType
+        {
+            None = 0,
+            DriveThroughCutting = 1,
+            StopAndGo10Cutting = 2,
+            StopAndGo20Cutting = 3,
+            StopAndGo30Cutting = 4,
+            DisqualifiedCutting = 5,
+            RemoveBestLaptimeCutting = 6,
+            DriveThroughPitSpeeding = 7,
+            StopAndGo10PitSpeeding = 8,
+            StopAndGo20PitSpeeding = 9,
+            StopAndGo30PitSpeeding = 10,
+            DisqualifiedPitSpeeding = 11,
+            RemoveBestLaptimePitSpeeding = 12,
+            DisqualifiedIgnoredMandatoryPit = 13,
+            PostRaceTime = 14,
+            DisqualifiedTrolling = 15,
+            DisqualifiedPitEntry = 16,
+            DisqualifiedPitExit = 17,
+            DisqualifiedWrongway = 18,
+            DriveThroughIgnoredDriverStint = 19,
+            DisqualifiedIgnoredDriverStint = 20,
+            DisqualifiedExceededDriverStintLimit = 21
+        }
+
+        public enum SessionType
+        {
+            Unknown = -1,
+            Practice = 0,
+            Qualify = 1,
+            Race = 2,
+            Hotlap = 3,
+            Timeattack = 4,
+            Drift = 5,
+            Drag = 6,
+            Hotstint = 7,
+            HotstintSuperpole = 8
+        }
+
+        public enum Status
+        {
+            Off = 0,
+            Replay = 1,
+            Live = 2,
+            Pause = 3
+        }
+
+        public enum WheelsType
+        {
+            FrontLeft = 0,
+            FrontRight = 1,
+            RearLeft = 2,
+            RearRight = 3
+        }
+
+        public enum TrackGripStatus
+        {
+            Green = 0,
+            Fast = 1,
+            Optimum = 2,
+            Greasy = 3,
+            Damp = 4,
+            Wet = 5,
+            Flooded = 6
+        }
+
+        public enum RainIntensity
+        {
+            NoRain = 0,
+            Drizzle = 1,
+            LightRain = 2,
+            MediumRain = 3,
+            HeavyRain = 4,
+            Thunderstorm = 5
+        }
+    }
+
+    namespace Data
+    {
+
+        /// <summary>
+        /// The following members change at each graphic step. They all refer to
+        /// the player’s car.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential, Pack = 4, CharSet = CharSet.Unicode)]
+        [Serializable]
+        public struct SPageFilePhysics
+        {
+            public int PacketId; // Current step index
+            public float Gas; // Gas pedal input value (from -0 to 1.0)
+            public float Brake; // Brake pedal input value (from -0 to 1.0)
+            public float Fuel; // Amount of fuel remaining in kg
+            public int Gear; // Current gear
+            public int Rpm; // Engine revolutions per minute
+            public float SteerAngle; // Steering input value (from -1.0 to 1.0)
+            public float SpeedKmh; // Car speed in km/h
+            public Coords Velocity; // Car velocity vector in global coordinates
+            public Coords AccG; // Car acceleration vector in global coordinates
+            public Wheels<float> WheelSlip; // Tyre slip for each tyre
+            public Wheels<float> WheelLoad; // Wheel load for each tyre
+            public Wheels<float> WheelPressure; // Tyre pressure
+            public Wheels<float> WheelAngularSpeed; // Wheel angular speed in rad/s
+            public Wheels<float> TyreWear; // Tyre wear
+            public Wheels<float> TyreDirtyLevel; // Dirt accumulated on tyre surface
+            public Wheels<float> TyreCoreTemp; // Tyre rubber core temperature
+            public Wheels<float> CamberRAD; // Wheels camber in radians
+            public Wheels<float> SuspensionTravel; // Suspension travel
+            public float Drs; // DRS on
+            public float Tc; // TC in action
+            public float Heading; // Car yaw orientation
+            public float Pitch; // Car pitch orientation
+            public float Roll; // Car roll orientation
+            public float CgHeight; // Centre of gravity height
+            public Damage CarDamage; // Car damage
+            public int NumberOfTyresOut; // Number of tyres out of track
+            public int PitLimiterOn; // Pit limiter is on
+            public float Abs; // ABS in action
+            public float KersCharge; // Not used in ACC
+            public float KersInput; // Not used in ACC
+            public int AutoshifterOn; // Automatic transmission on
+            public RideHeight RideHeight; // Ride height
+            public float TurboBoost; // Car turbo level
+            public float Ballast; // Car ballast in kg / Not implemented
+            public float AirDensity; // Air density
+            public float AirTemp; // Air temperature
+            public float RoadTemp; // Road temperature
+            public Coords LocalAngularVel; // Car angular velocity vector in local coordinates
+            public float FinalFF; // Force feedback signal
+            public float PerformanceMeter; // Not used in ACC
+            public int EngineBrake; // Not used in ACC
+            public int ErsRecoveryLevel; // Not used in ACC
+            public int ErsPowerLevel; // Not used in ACC
+            public int ErsHeatCharging; // Not used in ACC
+            public int ErsIsCharging; // Not used in ACC
+            public float KersCurrentKJ; // Not used in ACC
+            public int DrsAvailable; // Not used in ACC
+            public int DrsEnabled; // Not used in ACC
+            public Wheels<float> BrakeTemp; // Brake discs temperatures
+            public float Clutch; // Clutch pedal input value (from -0 to 1.0)
+            public Wheels<float> TyreTempI; // Not shown in ACC
+            public Wheels<float> TyreTempM; // Not shown in ACC
+            public Wheels<float> TyreTempO; // Not shown in ACC
+            public int IsAIControlled; // Car is controlled by the AI
+            public Wheels<Coords> TyreContactPoint; // Tyre contact point global coordinates
+            public Wheels<Coords> TyreContactNormal; // Tyre contact normal
+            public Wheels<Coords> TyreContactHeading; // Tyre contact heading
+            public float BrakeBias; // Front brake bias, see Appendix 4
+            public Coords LocalVelocity; // Car velocity vector in local coordinates
+            public int P2PActivation; // Not used in ACC
+            public int P2PStatus; // Not used in ACC
+            public float CurrentMaxRpm; // Maximum engine rpm
+            public Wheels<float> Mz; // Not shown in ACC
+            public Wheels<float> Fx; // Not shown in ACC
+            public Wheels<float> Fy; // Not shown in ACC
+            public Wheels<float> SlipRatio; // Tyre slip ratio in radians
+            public Wheels<float> SlipAngle; // Tyre slip angle
+            public int TcinAction; // TC in action
+            public int AbsInAction; // ABS in action
+            public Wheels<float> SuspensionDamage; // Suspensions damage levels
+            public Wheels<float> TyreTemp; // Tyres core temperatures
+            public float WaterTemp; // Water Temperature
+            public Wheels<float> BrakePressure; // Brake pressure see Appendix 2
+            public int FrontBrakeCompound; // Brake pad compund front
+            public int RearBrakeCompound; // Brake pad compund rear
+            public Wheels<float> PadLife; // Brake pad wear
+            public Wheels<float> DiscLife; // Brake disk wear
+            public int IgnitionOn; // Ignition switch set to on?
+            public int StarterEngineOn; // Starter Switch set to on?
+            public int IsEngineRunning; // Engine running?
+            public float KerbVibration; // vibrations sent to the FFB, could be used for motion rigs
+            public float SlipVibrations; // vibrations sent to the FFB, could be used for motion rigs
+            public float GVibrations; // vibrations sent to the FFB, could be used for motion rigs
+            public float AbsVibrations; // vibrations sent to the FFB, could be used for motion rigs
+        }
+
+        /// <summary>
+        /// The following members are updated at each graphical step. They mostly
+        /// refer to player’s car except for carCoordinates and carID, which refer
+        /// to the cars currently on track.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential, Pack = 4, CharSet = CharSet.Unicode)]
+        [Serializable]
+        public struct SPageFileGraphic
+        {
+            public int PacketId; // Current step index
+            public Constant.Status Status;
+            public Constant.SessionType Session;
+            [MarshalAsAttribute(UnmanagedType.ByValTStr, SizeConst = 15)]
+            public string CurrentTime; // Current lap time in wide character
+            [MarshalAsAttribute(UnmanagedType.ByValTStr, SizeConst = 15)]
+            public string LastTime; // Last lap time in wide character
+            [MarshalAsAttribute(UnmanagedType.ByValTStr, SizeConst = 15)]
+            public string BestTime; // Best lap time in wide character
+            [MarshalAsAttribute(UnmanagedType.ByValTStr, SizeConst = 15)]
+            public string Split; // Last split time in wide character
+            public int CompletedLaps; // No of completed laps
+            public int Position; // Current player position
+            public int ICurrentTime; // Current lap time in milliseconds
+            public int ILastTime; // Last lap time in milliseconds
+            public int IBestTime; // Best lap time in milliseconds
+            public float SessionTimeLeft; // Session time left
+            public float DistanceTraveled; // Distance travelled in the current stint
+            public int IsInPit; // Car is pitting
+            public int CurrentSectorIndex; // Current track sector
+            public int LastSectorTime; // Last sector time in milliseconds
+            public int NumberOfLaps; // Number of completed laps
+            [MarshalAsAttribute(UnmanagedType.ByValTStr, SizeConst = 33)]
+            public string TyreCompound; // Tyre compound used
+            public float ReplayTimeMultiplier; // Not used in ACC
+            public float NormalizedCarPosition; // Car position on track spline(0.0 start to 1.0 finish)
+            public int ActiveCars; // Number of cars on track
+            [MarshalAsAttribute(UnmanagedType.ByValArray, SizeConst = 60)]
+            public Coords[] CarCoordinates; // Coordinates of cars on track
+            [MarshalAsAttribute(UnmanagedType.ByValArray, SizeConst = 60)]
+            public int[] CarID; // Car IDs of cars on track
+            public int PlayerCarID; // Player Car ID
+            public float PenaltyTime; // Penalty time to wait
+            public Constant.FlagType Flag;
+            public Constant.PenaltyType Penalty;
+            public int IdealLineOn; // Ideal line on
+            public int IsInPitLane; // Car is in pit lane
+            public float SurfaceGrip; // Ideal line friction coefficient
+            public int MandatoryPitDone; // Mandatory pit is completed
+            public float WindSpeed; // Wind speed in m/s
+            public float WindDirection; // wind direction in radians
+            public int IsSetupMenuVisible; // Car is working on setup
+            public int MainDisplayIndex; // current car main display index, see Appendix 1
+            public int SecondaryDisplyIndex; // current car secondary display index
+            public int Tc; // Traction control level
+            public int TcCut; // Traction control cut level
+            public int EngineMap; // Current engine map
+            public int Abs; // ABS level
+            public float FuelXLap; // Average fuel consumed per lap in liters
+            public int RainLights; // Rain lights on
+            public int FlashingLights; // Flashing lights on
+            public int LightsStage; // Current lights stage
+            public float ExhaustTemperature; // Exhaust temperature
+            public int WiperLV; // Current wiper stage
+            public int DriverStintTotalTimeLeft; // Time the driver is allowed to drive/race(ms)
+            public int DriverStintTimeLeft; // Time the driver is allowed to drive/stint(ms)
+            public int RainTyres; // Are rain tyres equipped
+            public int SessionIndex;
+            public float UsedFuel; // Used fuel since last time refueling
+            [MarshalAsAttribute(UnmanagedType.ByValTStr, SizeConst = 15)]
+            public string DeltaLapTime; // Delta time in wide character
+            public int IDeltaLapTime; // Delta time time in milliseconds
+            [MarshalAsAttribute(UnmanagedType.ByValTStr, SizeConst = 15)]
+            public string EstimatedLapTime; // Estimated lap time in wide character
+            public int IEstimatedLapTime; // Estimated lap time in milliseconds
+            public int IsDeltaPositive; // Delta positive(1) or negative(0)
+            public int ISplit; // Last split time in milliseconds
+            public int IsValidLap; // Check if Lap is valid for timing
+            public float FuelEstimatedLaps; // Laps possible with current fuel level
+            [MarshalAsAttribute(UnmanagedType.ByValTStr, SizeConst = 33)]
+            public string TrackStatus; // Status of track
+            public int MissingMandatoryPits; // Mandatory pitstops the player still has to do
+            public float Clock; // Time of day in seconds
+            public int DirectionLightsLeft; // Is Blinker left on
+            public int DirectionLightsRight; // Is Blinker right on
+            public int GlobalYellow; // Yellow Flag is out?
+            public int GlobalYellow1; // Yellow Flag in Sector 1 is out?
+            public int GlobalYellow2; // Yellow Flag in Sector 2 is out?
+            public int GlobalYellow3; // Yellow Flag in Sector 3 is out?
+            public int GlobalWhite; // White Flag is out?
+            public int GlobalGreen; // Green Flag is out?
+            public int GlobalChequered; // Checkered Flag is out?
+            public int GlobalRed; // Red Flag is out?
+            public int MfdTyreSet; // # of tyre set on the MFD
+            public float MfdFuelToAdd; // How much fuel to add on the MFD
+            public Wheels<float> MfdTyrePressure; // Tyre pressures on the MFD
+            public Constant.TrackGripStatus TrackGripStatus;
+            public Constant.RainIntensity RainIntensity;
+            public Constant.RainIntensity RainIntensityIn10min;
+            public Constant.RainIntensity RainIntensityIn30min;
+            public int CurrentTyreSet; // Tyre Set currently in use
+            public int StrategyTyreSet; // Next Tyre set per strategy int gapAhead Distance in ms to car in front int gapBehind Distance in ms to car behind
+        }
+
+        /// <summary>
+        /// The following members are initialized when the instance starts and
+        /// never changes until the instance is closed.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential, Pack = 4, CharSet = CharSet.Unicode)]
+        [Serializable]
+        public struct SPageFileStatic
+        {
+            [MarshalAsAttribute(UnmanagedType.ByValTStr, SizeConst = 15)]
+            public string SmVersion; // Shared memory version
+            [MarshalAsAttribute(UnmanagedType.ByValTStr, SizeConst = 15)]
+            public string AcVersion; // Assetto Corsa version
+            public int NumberOfSessions; // Number of sessions
+            public int NumCars; // Number of cars
+            [MarshalAsAttribute(UnmanagedType.ByValTStr, SizeConst = 33)]
+            public string CarModel; // Player car model see Appendix 2
+            public string Track; // Track name
+            [MarshalAsAttribute(UnmanagedType.ByValTStr, SizeConst = 33)]
+            public string PlayerName; // Player name
+            [MarshalAsAttribute(UnmanagedType.ByValTStr, SizeConst = 33)]
+            public string PlayerSurname; // Player surname
+            [MarshalAsAttribute(UnmanagedType.ByValTStr, SizeConst = 33)]
+            public string PlayerNick; // Player nickname
+            public int SectorCount; // Number of sectors
+            public float MaxTorque; // Not shown in ACC
+            public float MaxPower; // Not shown in ACC
+            public int MaxRpm; // Maximum rpm
+            public float MaxFuel; // Maximum fuel tank capacity
+            public Wheels<float> SuspensionMaxTravel; // Not shown in ACC
+            public Wheels<float> TyreRadius; // Not shown in ACC
+            public float MaxTurboBoost; // Maximum turbo boost
+            public float Deprecated1;
+            public float Deprecated2;
+            public int PenaltiesEnabled; // Penalties enabled
+            public float AidFuelRate; // Fuel consumption rate
+            public float AidTireRate; // Tyre wear rate
+            public float AidMechanicalDamage; // Mechanical damage rate
+            public float AllowTyreBlankets; // Not allowed in Blancpain endurance series
+            public float AidStability; // Stability control used
+            public int AidAutoclutch; // Auto clutch used
+            public int AidAutoBlip; // Always true in ACC
+            public int HasDds; // Not used in ACC
+            public int HasErs; // Not used in ACC
+            public int HasKers; // Not used in ACC
+            public float KersMaxJ; // Not used in ACC
+            public int EngineBrakeSettingsCount; // Not used in ACC
+            public int ErsPowerControllerCount; // Not used in ACC
+            public float TrackSplineLength; // Not used in ACC
+            public char TrackConfiguration; // Not used in ACC
+            public float ErsMaxJ; // Not used in ACC
+            public int IsTimedRace; // Not used in ACC
+            public int HasExtraLap; // Not used in ACC
+            [MarshalAsAttribute(UnmanagedType.ByValTStr, SizeConst = 33)]
+            public string CarSkin; // Not used in ACC
+            public int ReversedGridPositions; // Not used in ACC
+            public int PitWindowStart; // Pit window opening time
+            public int PitWindowEnd; // Pit windows closing time
+            public int IsOnline; // If is a multiplayer session
+            [MarshalAsAttribute(UnmanagedType.ByValTStr, SizeConst = 33)]
+            public string DryTyresName; // Name of the dry tyres
+            [MarshalAsAttribute(UnmanagedType.ByValTStr, SizeConst = 33)]
+            public string WetTyresName; // Name of the wet tyres
+
+            public int SmVersionMajor => Int32.Parse(SmVersion.Split('.')[0]);
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 4)]
+        [Serializable]
+        public struct Wheels<T>
+        {
+            T FL;
+            T FR;
+            T RL;
+            T RR;
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 4)]
+        [Serializable]
+        public struct Coords
+        {
+            float X;
+            float Y;
+            float Z;
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 4)]
+        [Serializable]
+        public struct Damage
+        {
+            float Front;
+            float Rear;
+            float Left;
+            float Right;
+            float Center;
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 4)]
+        [Serializable]
+        public struct RideHeight
+        {
+            float Front;
+            float Rear;
+        }
+    }
+}

--- a/src/RaceDirector/Pipeline/Games/ACC/Game.cs
+++ b/src/RaceDirector/Pipeline/Games/ACC/Game.cs
@@ -12,7 +12,7 @@ namespace RaceDirector.Pipeline.Games.ACC
     {
         public record Config(TimeSpan PollingInterval); // TODO remove when config done
 
-        private Config _config;
+        private readonly Config _config;
 
         public string GameName => "ACC";
 

--- a/src/RaceDirector/Pipeline/Games/ACC/Game.cs
+++ b/src/RaceDirector/Pipeline/Games/ACC/Game.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.Versioning;
 using System.Threading.Tasks.Dataflow;
+using RaceDirector.Pipeline.Telemetry.V0;
 
 namespace RaceDirector.Pipeline.Games.ACC
 {
@@ -20,7 +21,7 @@ namespace RaceDirector.Pipeline.Games.ACC
             _config = config;
         }
 
-        public ISourceBlock<Pipeline.Telemetry.V0.IGameTelemetry> CreateTelemetrySource()
+        public IObservable<IGameTelemetry> CreateTelemetryObservable()
         {
             throw new NotImplementedException();
         }

--- a/src/RaceDirector/Pipeline/Games/ACC/Game.cs
+++ b/src/RaceDirector/Pipeline/Games/ACC/Game.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Runtime.Versioning;
+using System.Threading.Tasks.Dataflow;
+
+namespace RaceDirector.Pipeline.Games.ACC
+{
+    [SupportedOSPlatform("windows")]
+    public class Game : IGame
+    {
+        public record Config(TimeSpan PollingInterval); // TODO remove when config done
+
+        private Config _config;
+
+        public string GameName => "ACC";
+
+        public string[] GameProcessNames => new[] { "AC2-Win64-Shipping" };
+
+        public Game(Config config)
+        {
+            _config = config;
+        }
+
+        public ISourceBlock<Pipeline.Telemetry.V0.IGameTelemetry> CreateTelemetrySource()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/RaceDirector/Pipeline/Games/ACC/TelemetryConverter.cs
+++ b/src/RaceDirector/Pipeline/Games/ACC/TelemetryConverter.cs
@@ -6,49 +6,58 @@ namespace RaceDirector.Pipeline.Games.ACC
 {
     internal class TelemetryConverter
     {
-        internal GameTelemetry Transform(Contrib.Data.SPageFilePhysics physicsData, Contrib.Data.SPageFileGraphic graphicData, Contrib.Data.SPageFileStatic staticData)
+
+        internal GameTelemetry Transform(ref Contrib.Data.Shared shared)
         {
-            if (staticData.SmVersionMajor != Contrib.Constant.SmVersionMajor)
+            if (shared.Static.SmVersionMajor != Contrib.Constant.SmVersionMajor)
                 throw new ArgumentException("Incompatible major version");
             return new GameTelemetry(
-                GameState: GameState(physicsData, graphicData, staticData),
+                GameState: GameState(ref shared),
                 UsingVR: null,
-                Event: Event(physicsData, graphicData, staticData),
-                Session: Session(physicsData, graphicData, staticData),
-                Vehicles: Vehicles(physicsData, graphicData, staticData),
-                FocusedVehicle: FocusedVehicle(physicsData, graphicData, staticData),
-                Player: Player(physicsData, graphicData, staticData)
+                Event: Event(ref shared),
+                Session: Session(ref shared),
+                Vehicles: Vehicles(ref shared),
+                FocusedVehicle: FocusedVehicle(ref shared),
+                Player: Player(ref shared)
             );
         }
 
-        private Player? Player(Contrib.Data.SPageFilePhysics physicsData, Contrib.Data.SPageFileGraphic graphicData, Contrib.Data.SPageFileStatic staticData)
+        private GameState GameState(ref Contrib.Data.Shared shared)
         {
-            throw new NotImplementedException();
+            return shared.Graphic.Status switch
+            {
+                Contrib.Constant.Status.Off => Telemetry.V0.GameState.Replay, // recorded replay
+                Contrib.Constant.Status.Replay => Telemetry.V0.GameState.Replay, // in-game replay
+                Contrib.Constant.Status.Live when shared.Static.AidMechanicalDamage < 0 => Telemetry.V0.GameState.Menu, // in-game menu
+                Contrib.Constant.Status.Live => Telemetry.V0.GameState.Driving,
+                Contrib.Constant.Status.Pause => Telemetry.V0.GameState.Paused, // single player game paused
+                _ => throw new ArgumentException("Unknown game state")
+            };
         }
 
-        private Vehicle? FocusedVehicle(Contrib.Data.SPageFilePhysics physicsData, Contrib.Data.SPageFileGraphic graphicData, Contrib.Data.SPageFileStatic staticData)
+        private Event? Event(ref Contrib.Data.Shared shared)
         {
-            throw new NotImplementedException();
+            return null;
         }
 
-        private Vehicle[] Vehicles(Contrib.Data.SPageFilePhysics physicsData, Contrib.Data.SPageFileGraphic graphicData, Contrib.Data.SPageFileStatic staticData)
+        private Session? Session(ref Contrib.Data.Shared shared)
         {
-            throw new NotImplementedException();
+            return null;
         }
 
-        private Session? Session(Contrib.Data.SPageFilePhysics physicsData, Contrib.Data.SPageFileGraphic graphicData, Contrib.Data.SPageFileStatic staticData)
+        private Vehicle[] Vehicles(ref Contrib.Data.Shared shared)
         {
-            throw new NotImplementedException();
+            return Array.Empty<Vehicle>();
         }
 
-        private Event? Event(Contrib.Data.SPageFilePhysics physicsData, Contrib.Data.SPageFileGraphic graphicData, Contrib.Data.SPageFileStatic staticData)
+        private Vehicle? FocusedVehicle(ref Contrib.Data.Shared shared)
         {
-            throw new NotImplementedException();
+            return null;
         }
 
-        private GameState GameState(Contrib.Data.SPageFilePhysics physicsData, Contrib.Data.SPageFileGraphic graphicData, Contrib.Data.SPageFileStatic staticData)
+        private Player? Player(ref Contrib.Data.Shared shared)
         {
-            throw new NotImplementedException();
+            return null;
         }
     }
 }

--- a/src/RaceDirector/Pipeline/Games/ACC/TelemetryConverter.cs
+++ b/src/RaceDirector/Pipeline/Games/ACC/TelemetryConverter.cs
@@ -1,0 +1,54 @@
+﻿using RaceDirector.Pipeline.Telemetry;
+using RaceDirector.Pipeline.Telemetry.V0;
+using System;
+
+namespace RaceDirector.Pipeline.Games.ACC
+{
+    internal class TelemetryConverter
+    {
+        internal GameTelemetry Transform(Contrib.Data.SPageFilePhysics physicsData, Contrib.Data.SPageFileGraphic graphicData, Contrib.Data.SPageFileStatic staticData)
+        {
+            if (staticData.SmVersionMajor != Contrib.Constant.SmVersionMajor)
+                throw new ArgumentException("Incompatible major version");
+            return new GameTelemetry(
+                GameState: GameState(physicsData, graphicData, staticData),
+                UsingVR: null,
+                Event: Event(physicsData, graphicData, staticData),
+                Session: Session(physicsData, graphicData, staticData),
+                Vehicles: Vehicles(physicsData, graphicData, staticData),
+                FocusedVehicle: FocusedVehicle(physicsData, graphicData, staticData),
+                Player: Player(physicsData, graphicData, staticData)
+            );
+        }
+
+        private Player? Player(Contrib.Data.SPageFilePhysics physicsData, Contrib.Data.SPageFileGraphic graphicData, Contrib.Data.SPageFileStatic staticData)
+        {
+            throw new NotImplementedException();
+        }
+
+        private Vehicle? FocusedVehicle(Contrib.Data.SPageFilePhysics physicsData, Contrib.Data.SPageFileGraphic graphicData, Contrib.Data.SPageFileStatic staticData)
+        {
+            throw new NotImplementedException();
+        }
+
+        private Vehicle[] Vehicles(Contrib.Data.SPageFilePhysics physicsData, Contrib.Data.SPageFileGraphic graphicData, Contrib.Data.SPageFileStatic staticData)
+        {
+            throw new NotImplementedException();
+        }
+
+        private Session? Session(Contrib.Data.SPageFilePhysics physicsData, Contrib.Data.SPageFileGraphic graphicData, Contrib.Data.SPageFileStatic staticData)
+        {
+            throw new NotImplementedException();
+        }
+
+        private Event? Event(Contrib.Data.SPageFilePhysics physicsData, Contrib.Data.SPageFileGraphic graphicData, Contrib.Data.SPageFileStatic staticData)
+        {
+            throw new NotImplementedException();
+        }
+
+        private GameState GameState(Contrib.Data.SPageFilePhysics physicsData, Contrib.Data.SPageFileGraphic graphicData, Contrib.Data.SPageFileStatic staticData)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/RaceDirector/Pipeline/Games/ACC/TelemetryConverter.cs
+++ b/src/RaceDirector/Pipeline/Games/ACC/TelemetryConverter.cs
@@ -7,10 +7,22 @@ namespace RaceDirector.Pipeline.Games.ACC
 {
     internal class TelemetryConverter
     {
+        private static GameTelemetry NoMMFiles = new(
+            GameState: GameState.Menu,
+            UsingVR: null,
+            Event: null,
+            Session: null,
+            Vehicles: Array.Empty<Vehicle>(),
+            FocusedVehicle: null,
+            Player: null
+        );
 
         internal GameTelemetry Transform(ref Contrib.Data.Shared sharedData)
         {
-            if (sharedData.Static.SmVersionMajor != Contrib.Constant.SmVersionMajor)
+            if (sharedData.Static.SmVersion.Length == 0)
+                return NoMMFiles;
+            var smVersionMajor = Int32.Parse(sharedData.Static.SmVersion.Split('.')[0]);
+            if (smVersionMajor != Contrib.Constant.SmVersionMajor)
                 throw new ArgumentException("Incompatible major version");
             return new GameTelemetry(
                 GameState: ToGameState(ref sharedData),

--- a/src/RaceDirector/Pipeline/Games/ACC/TelemetryConverter.cs
+++ b/src/RaceDirector/Pipeline/Games/ACC/TelemetryConverter.cs
@@ -8,35 +8,35 @@ namespace RaceDirector.Pipeline.Games.ACC
     internal class TelemetryConverter
     {
 
-        internal GameTelemetry Transform(ref Contrib.Data.Shared shared)
+        internal GameTelemetry Transform(ref Contrib.Data.Shared sharedData)
         {
-            if (shared.Static.SmVersionMajor != Contrib.Constant.SmVersionMajor)
+            if (sharedData.Static.SmVersionMajor != Contrib.Constant.SmVersionMajor)
                 throw new ArgumentException("Incompatible major version");
             return new GameTelemetry(
-                GameState: ToGameState(ref shared),
+                GameState: ToGameState(ref sharedData),
                 UsingVR: null, // TODO Check if it can be inferred from process parameters
-                Event: ToEvent(ref shared),
-                Session: ToSession(ref shared),
-                Vehicles: ToVehicles(ref shared),
-                FocusedVehicle: ToFocusedVehicle(ref shared),
-                Player: ToPlayer(ref shared)
+                Event: ToEvent(ref sharedData),
+                Session: ToSession(ref sharedData),
+                Vehicles: ToVehicles(ref sharedData),
+                FocusedVehicle: ToFocusedVehicle(ref sharedData),
+                Player: ToPlayer(ref sharedData)
             );
         }
 
-        private GameState ToGameState(ref Contrib.Data.Shared shared)
+        private static GameState ToGameState(ref Contrib.Data.Shared sharedData)
         {
-            return shared.Graphic.Status switch
+            return sharedData.Graphic.Status switch
             {
                 Contrib.Constant.Status.Off => GameState.Replay, // recorded replay
                 Contrib.Constant.Status.Replay => GameState.Replay, // in-game replay
-                Contrib.Constant.Status.Live when shared.Physics.WaterTemp == 0 => GameState.Menu, // in-game menu
+                Contrib.Constant.Status.Live when sharedData.Physics.WaterTemp == 0 => GameState.Menu, // in-game menu
                 Contrib.Constant.Status.Live => GameState.Driving,
                 Contrib.Constant.Status.Pause => GameState.Paused, // single player game paused
                 _ => throw new ArgumentException("Unknown game state")
             };
         }
 
-        private Event? ToEvent(ref Contrib.Data.Shared shared)
+        private static Event? ToEvent(ref Contrib.Data.Shared sharedData)
         {
             return new Event(
                 TrackLayout: new TrackLayout
@@ -47,13 +47,13 @@ namespace RaceDirector.Pipeline.Games.ACC
                     // Will have to record them on track and save them in config.
                     SectorsEnd: Array.Empty<IFraction<IDistance>>() // TODO
                 ),
-                FuelRate: shared.Static.AidFuelRate
+                FuelRate: sharedData.Static.AidFuelRate
             );
         }
 
-        private Session? ToSession(ref Contrib.Data.Shared shared)
+        private static Session? ToSession(ref Contrib.Data.Shared sharedData)
         {
-            var maybeSessionType = ToSessionType(shared.Graphic.Session);
+            var maybeSessionType = ToSessionType(sharedData.Graphic.Session);
             if (maybeSessionType is null)
                 return null;
 
@@ -99,7 +99,7 @@ namespace RaceDirector.Pipeline.Games.ACC
             );
         }
 
-        private SessionType? ToSessionType(Contrib.Constant.SessionType session) => session switch
+        private static SessionType? ToSessionType(Contrib.Constant.SessionType session) => session switch
         {
             Contrib.Constant.SessionType.Practice => SessionType.Practice,
             Contrib.Constant.SessionType.Qualify => SessionType.Qualify,
@@ -113,12 +113,12 @@ namespace RaceDirector.Pipeline.Games.ACC
             _ => null
         };
 
-        private Vehicle[] ToVehicles(ref Contrib.Data.Shared shared)
+        private static Vehicle[] ToVehicles(ref Contrib.Data.Shared sharedData)
         {
             return Array.Empty<Vehicle>();
         }
 
-        private Vehicle? ToVehicle(ref Contrib.Data.Shared shared)
+        private static Vehicle? ToVehicle(ref Contrib.Data.Shared sharedData)
         {
             return new Vehicle
             (
@@ -173,7 +173,7 @@ namespace RaceDirector.Pipeline.Games.ACC
             );
         }
 
-        private Vehicle? ToFocusedVehicle(ref Contrib.Data.Shared shared)
+        private static Vehicle? ToFocusedVehicle(ref Contrib.Data.Shared sharedData)
         {
             return new Vehicle
             (
@@ -228,7 +228,7 @@ namespace RaceDirector.Pipeline.Games.ACC
             );
         }
 
-        private Player? ToPlayer(ref Contrib.Data.Shared shared)
+        private static Player? ToPlayer(ref Contrib.Data.Shared sharedData)
         {
             return new Player
             (

--- a/src/RaceDirector/Pipeline/Games/R3E/Contrib.cs
+++ b/src/RaceDirector/Pipeline/Games/R3E/Contrib.cs
@@ -35,7 +35,7 @@ using System.Runtime.InteropServices;
 
 namespace RaceDirector.Pipeline.Games.R3E.Contrib
 {
-    public class Constant
+    public static class Constant
     {
         public const string SharedMemoryName = "$R3E";
 

--- a/src/RaceDirector/Pipeline/Games/R3E/Game.cs
+++ b/src/RaceDirector/Pipeline/Games/R3E/Game.cs
@@ -31,7 +31,7 @@ namespace RaceDirector.Pipeline.Games.R3E
                     try
                     {
                         var shared = mmReader.Read();
-                        var telemetry = telemetryConverter.Transform(shared);
+                        var telemetry = telemetryConverter.Transform(ref shared);
                         return Observable.Return(telemetry);
                     }
                     catch

--- a/src/RaceDirector/Pipeline/Games/R3E/Game.cs
+++ b/src/RaceDirector/Pipeline/Games/R3E/Game.cs
@@ -24,13 +24,15 @@ namespace RaceDirector.Pipeline.Games.R3E
         public IObservable<Pipeline.Telemetry.V0.IGameTelemetry> CreateTelemetryObservable()
         {
             var mmReader = new MemoryMappedFileReader<Contrib.Data.Shared>(Contrib.Constant.SharedMemoryName);
-            var telemetry = new Telemetry();
+            var telemetryConverter = new TelemetryConverter();
             return Observable.Interval(_config.PollingInterval)
                 .SelectMany(_ =>
                 {
                     try
                     {
-                        return Observable.Return(telemetry.Transform(mmReader.Read()));
+                        var shared = mmReader.Read();
+                        var telemetry = telemetryConverter.Transform(shared);
+                        return Observable.Return(telemetry);
                     }
                     catch
                     {

--- a/src/RaceDirector/Pipeline/Games/R3E/Game.cs
+++ b/src/RaceDirector/Pipeline/Games/R3E/Game.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Reactive.Linq;
 using System.Runtime.Versioning;
+using RaceDirector.Pipeline.Telemetry.V0;
 
 namespace RaceDirector.Pipeline.Games.R3E
 {
@@ -21,7 +22,7 @@ namespace RaceDirector.Pipeline.Games.R3E
             _config = config;
         }
 
-        public IObservable<Telemetry.V0.IGameTelemetry> CreateTelemetryObservable()
+        public IObservable<IGameTelemetry> CreateTelemetryObservable()
         {
             var mmReader = new MemoryMappedFileReader<Contrib.Data.Shared>(Contrib.Constant.SharedMemoryName);
             var telemetryConverter = new TelemetryConverter();
@@ -36,7 +37,7 @@ namespace RaceDirector.Pipeline.Games.R3E
                     }
                     catch
                     {
-                        return Observable.Empty<Pipeline.Telemetry.GameTelemetry>();
+                        return Observable.Empty<IGameTelemetry>();
                     }
                 });
         }

--- a/src/RaceDirector/Pipeline/Games/R3E/Game.cs
+++ b/src/RaceDirector/Pipeline/Games/R3E/Game.cs
@@ -21,7 +21,7 @@ namespace RaceDirector.Pipeline.Games.R3E
             _config = config;
         }
 
-        public IObservable<Pipeline.Telemetry.V0.IGameTelemetry> CreateTelemetryObservable()
+        public IObservable<Telemetry.V0.IGameTelemetry> CreateTelemetryObservable()
         {
             var mmReader = new MemoryMappedFileReader<Contrib.Data.Shared>(Contrib.Constant.SharedMemoryName);
             var telemetryConverter = new TelemetryConverter();

--- a/src/RaceDirector/Pipeline/Games/R3E/TelemetryConverter.cs
+++ b/src/RaceDirector/Pipeline/Games/R3E/TelemetryConverter.cs
@@ -61,7 +61,8 @@ namespace RaceDirector.Pipeline.Games.R3E
             if (sharedData.LayoutLength < 0)
                 return null;
             var layoutLength = IDistance.FromM(sharedData.LayoutLength);
-            var sectors = ValuesPerSector(ref sharedData.SectorStartFactors, i => DistanceFraction.FromTotal(layoutLength, i));
+            var sectors = ValuesPerSector(ref sharedData.SectorStartFactors,
+                i => DistanceFraction.FromTotal(layoutLength, i));
             return new TrackLayout(
                 SectorsEnd: sectors
             );
@@ -250,7 +251,7 @@ namespace RaceDirector.Pipeline.Games.R3E
             return new StartLights
             (
                 Color: LightColor.Red,
-                Lit: new BoundedValue<uint>((uint)startLights, MaxLights)
+                Lit: new BoundedValue<uint>((uint) startLights, MaxLights)
             );
         }
 
@@ -263,9 +264,10 @@ namespace RaceDirector.Pipeline.Games.R3E
             {
                 vehicles[i] = ToVehicle(ref sharedData.DriverData[i], ref sharedData);
             }
+
             return vehicles;
         }
-        
+
         private Vehicle ToVehicle(ref Contrib.Data.DriverData driverData, ref Contrib.Data.Shared sharedData)
         {
             return new Vehicle
@@ -277,7 +279,7 @@ namespace RaceDirector.Pipeline.Games.R3E
                 ControlType: ControlType.Replay, // TODO
                 Position: 42, // TODO
                 PositionClass: SafeUInt32(driverData.PlaceClass),
-                GapAhead: TimeSpan.FromSeconds(driverData.TimeDeltaFront),   // It can be negative!
+                GapAhead: TimeSpan.FromSeconds(driverData.TimeDeltaFront), // It can be negative!
                 GapBehind: TimeSpan.FromSeconds(driverData.TimeDeltaBehind), // It can be negative!
                 CompletedLaps: SafeUInt32(driverData.CompletedLaps),
                 LapValid: ToLapValid(driverData.CurrentLapValid),
@@ -293,7 +295,8 @@ namespace RaceDirector.Pipeline.Games.R3E
                     )
                 ),
                 BestSectors: null, // TODO
-                CurrentLapDistance: DistanceFraction.FromTotal(IDistance.FromM(sharedData.LayoutLength), IDistance.FromM(driverData.LapDistance)),
+                CurrentLapDistance: DistanceFraction.FromTotal(IDistance.FromM(sharedData.LayoutLength),
+                    IDistance.FromM(driverData.LapDistance)),
                 Location: Vector3(ref driverData.Position, i => IDistance.FromM(i)),
                 Orientation: null, // TODO
                 Speed: ISpeed.FromMPS(42), // TODO
@@ -369,7 +372,8 @@ namespace RaceDirector.Pipeline.Games.R3E
                     )
                 ),
                 BestSectors: null, // TODO
-                CurrentLapDistance: DistanceFraction.Of(IDistance.FromM(sharedData.LapDistance), sharedData.LapDistanceFraction),
+                CurrentLapDistance: DistanceFraction.Of(IDistance.FromM(sharedData.LapDistance),
+                    sharedData.LapDistanceFraction),
                 Location: Vector3(ref sharedData.CarCgLocation, i => IDistance.FromM(i)),
                 Orientation: ToOrientation(ref sharedData.CarOrientation, i => IAngle.FromRad(i)),
                 Speed: ISpeed.FromMPS(sharedData.CarSpeed),
@@ -547,14 +551,17 @@ namespace RaceDirector.Pipeline.Games.R3E
                 ),
                 LocalAcceleration: Vector3(ref sharedData.Player.LocalAcceleration, IAcceleration.FromMPS2),
                 ClassBestLap: null, // TODO
-                ClassBestSectors: new Sectors // TODO are these the best sectors of the class leader or the best class sectors???
-                (
-                    Individual: ValuesPerSector(ref sharedData.BestIndividualSectorTimeLeaderClass, i => TimeSpan.FromSeconds(i)),
-                    Cumulative: Array.Empty<TimeSpan>() // TODO
-                ),
+                ClassBestSectors: new
+                    Sectors // TODO are these the best sectors of the class leader or the best class sectors???
+                    (
+                        Individual: ValuesPerSector(ref sharedData.BestIndividualSectorTimeLeaderClass,
+                            i => TimeSpan.FromSeconds(i)),
+                        Cumulative: Array.Empty<TimeSpan>() // TODO
+                    ),
                 PersonalBestSectors: new Sectors
                 (
-                    Individual: ValuesPerSector(ref sharedData.BestIndividualSectorTimeSelf, i => TimeSpan.FromSeconds(i)),
+                    Individual: ValuesPerSector(ref sharedData.BestIndividualSectorTimeSelf,
+                        i => TimeSpan.FromSeconds(i)),
                     Cumulative: Array.Empty<TimeSpan>() // TODO
                 ),
                 PersonalBestDelta: TimeSpan.FromSeconds(sharedData.TimeDeltaBestSelf),
@@ -577,22 +584,24 @@ namespace RaceDirector.Pipeline.Games.R3E
             if (sharedData.PitState == 1)
                 playerPitStop |= PlayerPitStop.Requested;
             foreach (var (pitActionFlag, playerPitStopFlag) in PitActionFlags)
-                if ((sharedData.PitAction & pitActionFlag) != 0) playerPitStop |= playerPitStopFlag;
+                if ((sharedData.PitAction & pitActionFlag) != 0)
+                    playerPitStop |= playerPitStopFlag;
             return playerPitStop;
         }
 
-        private static readonly (int, PlayerPitStop)[] PitActionFlags = {
-                (  1, PlayerPitStop.Preparing),
-                (  2, PlayerPitStop.ServingPenalty),
-                (  4, PlayerPitStop.DriverChange),
-                (  8, PlayerPitStop.Refuelling),
-                ( 16, PlayerPitStop.ChangeFrontTires),
-                ( 32, PlayerPitStop.ChangeRearTires),
-                ( 64, PlayerPitStop.RepairBody),
-                (128, PlayerPitStop.RepairFrontWing),
-                (256, PlayerPitStop.RepairRearWing),
-                (512, PlayerPitStop.RepairSuspension)
-            };
+        private static readonly (int, PlayerPitStop)[] PitActionFlags =
+        {
+            (1, PlayerPitStop.Preparing),
+            (2, PlayerPitStop.ServingPenalty),
+            (4, PlayerPitStop.DriverChange),
+            (8, PlayerPitStop.Refuelling),
+            (16, PlayerPitStop.ChangeFrontTires),
+            (32, PlayerPitStop.ChangeRearTires),
+            (64, PlayerPitStop.RepairBody),
+            (128, PlayerPitStop.RepairFrontWing),
+            (256, PlayerPitStop.RepairRearWing),
+            (512, PlayerPitStop.RepairSuspension)
+        };
 
         private static Orientation ToOrientation<T>(ref Contrib.Data.Orientation<T> value, Func<T, IAngle> f) =>
             new(Yaw: f(value.Yaw), Pitch: f(value.Pitch), Roll: f(value.Roll));
@@ -603,7 +612,7 @@ namespace RaceDirector.Pipeline.Games.R3E
             if (drs.Equipped <= 0)
                 return null;
             return new ActivationToggled
-                (
+            (
                 Available: drs.Available > 0,
                 Engaged: drs.Engaged > 0,
                 ActivationsLeft: new BoundedValue<uint>(
@@ -612,14 +621,14 @@ namespace RaceDirector.Pipeline.Games.R3E
                 )
             );
         }
-        
+
         private static WaitTimeToggled? ToPtp(ref Contrib.Data.Shared sharedData)
         {
             var ptp = sharedData.PushToPass;
             if (ptp.Available < 0)
                 return null;
             return new WaitTimeToggled
-                (
+            (
                 Available: ptp.Available > 0,
                 Engaged: ptp.Engaged > 0,
                 ActivationsLeft: new BoundedValue<uint>
@@ -636,11 +645,13 @@ namespace RaceDirector.Pipeline.Games.R3E
         {
             return new[]
             {
-                new[] {
+                new[]
+                {
                     ToTire(ref sharedData, new ITireExtractor.FrontLeft()),
                     ToTire(ref sharedData, new ITireExtractor.FrontRight())
                 },
-                new[] {
+                new[]
+                {
                     ToTire(ref sharedData, new ITireExtractor.RearLeft()),
                     ToTire(ref sharedData, new ITireExtractor.RearRight())
                 }
@@ -658,11 +669,14 @@ namespace RaceDirector.Pipeline.Games.R3E
                 Temperatures: new TemperaturesMatrix
                 (
                     CurrentTemperatures: new[]
-                    { new[] {
-                        ITemperature.FromC(tireTemps.CurrentTemp.Left),
-                        ITemperature.FromC(tireTemps.CurrentTemp.Center),
-                        ITemperature.FromC(tireTemps.CurrentTemp.Right)
-                    }},
+                    {
+                        new[]
+                        {
+                            ITemperature.FromC(tireTemps.CurrentTemp.Left),
+                            ITemperature.FromC(tireTemps.CurrentTemp.Center),
+                            ITemperature.FromC(tireTemps.CurrentTemp.Right)
+                        }
+                    },
                     OptimalTemperature: ITemperature.FromC(tireTemps.OptimalTemp),
                     ColdTemperature: ITemperature.FromC(tireTemps.ColdTemp),
                     HotTemperature: ITemperature.FromC(tireTemps.HotTemp)
@@ -713,7 +727,7 @@ namespace RaceDirector.Pipeline.Games.R3E
             return new BoundedValue<uint>(blueWarnings, 2);
         }
 
-        private static uint PositiveOrZero(int value) => value > 0 ? (uint)value : 0;
+        private static uint PositiveOrZero(int value) => value > 0 ? (uint) value : 0;
 
         private static string FromNullTerminatedByteArray(byte[] nullTerminated)
         {
@@ -727,14 +741,14 @@ namespace RaceDirector.Pipeline.Games.R3E
             new(X: f(value.X), Y: f(value.Y), Z: f(value.Z));
 
         private static TO[] ValuesPerSector<TI, TO>(ref Contrib.Data.Sectors<TI> value, Func<TI, TO> f) =>
-            new[] { f(value.Sector1), f(value.Sector2), f(value.Sector3) };
+            new[] {f(value.Sector1), f(value.Sector2), f(value.Sector3)};
 
         private static TO[] ValuesPerSector<TI, TO>(ref Contrib.Data.SectorStarts<TI> value, Func<TI, TO> f) =>
-            new[] { f(value.Sector1), f(value.Sector2), f(value.Sector3) };
+            new[] {f(value.Sector1), f(value.Sector2), f(value.Sector3)};
 
         private static uint SafeUInt32(int i, uint defaultValue = 0)
         {
-            return i < 0 ? defaultValue : (uint)i;
+            return i < 0 ? defaultValue : (uint) i;
         }
 
         private static bool? NullableBoolean(int i)
@@ -770,12 +784,13 @@ namespace RaceDirector.Pipeline.Games.R3E
                     break;
                 case 5:
                     if (_current != null)
-                        _current = _current with { Active = true };
+                        _current = _current with {Active = true};
                     break;
                 default:
-                    _current = _constructor((uint)newLevel);
+                    _current = _constructor((uint) newLevel);
                     break;
             }
+
             return _current;
         }
     }

--- a/src/RaceDirector/Pipeline/Games/R3E/TelemetryConverter.cs
+++ b/src/RaceDirector/Pipeline/Games/R3E/TelemetryConverter.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace RaceDirector.Pipeline.Games.R3E
 {
-    internal class Telemetry
+    internal class TelemetryConverter
     {
         private const uint MaxLights = 5;
 

--- a/src/RaceDirector/Plugin/DefaultPlugin.cs
+++ b/src/RaceDirector/Plugin/DefaultPlugin.cs
@@ -10,11 +10,14 @@ namespace RaceDirector.Plugin
     [SupportedOSPlatform("windows")]
     public class DefaultPlugin : IPlugin
     {
+        [SupportedOSPlatform("windows")]
         public void Init(IServiceCollection services)
         {
             services
                 .AddSingletonWithInterfaces(_ => new Pipeline.Games.R3E.Game.Config(TimeSpan.FromMilliseconds(15)))
                 .AddSingletonWithInterfaces<Pipeline.Games.R3E.Game>()
+                .AddSingletonWithInterfaces(_ => new Pipeline.Games.ACC.Game.Config(TimeSpan.FromMilliseconds(15)))
+                .AddSingletonWithInterfaces<Pipeline.Games.ACC.Game>()
                 .AddSingletonWithInterfaces(_ => new ProcessMonitorNode.Config(TimeSpan.FromSeconds(5)))
                 .AddTransientWithInterfaces<ProcessMonitorNode>()
                 .AddTransientWithInterfaces<TelemetryReaderNode>();

--- a/tests/Plugins/HUD.Tests/Pipeline/R3EDashTransformerTest.cs
+++ b/tests/Plugins/HUD.Tests/Pipeline/R3EDashTransformerTest.cs
@@ -1915,7 +1915,7 @@ static class GameTelemetryExensions
 
     public static GameTelemetry WithTrack(this GameTelemetry gt, Func<TrackLayout, TrackLayout> f)
     {
-        return gt.WithEvent(e => e with { Track = f( e.Track) });
+        return gt.WithEvent(e => e with { TrackLayout = f( e.TrackLayout) });
     }
 
     public static GameTelemetry WithSectorsEnd(this GameTelemetry gt, IFraction<IDistance>[] sectorsEnd)

--- a/tests/Plugins/HUD.Tests/Pipeline/R3EDashTransformerTest.cs
+++ b/tests/Plugins/HUD.Tests/Pipeline/R3EDashTransformerTest.cs
@@ -57,6 +57,17 @@ namespace HUD.Tests.Pipeline
         {
             var result = ToR3EDash(NewGt() with { GameState = GameState.Driving });
 
+            Assert.Equal(0, result.Path("GamePaused").GetInt32());
+            Assert.Equal(0, result.Path("GameInMenus").GetInt32());
+            Assert.Equal(0, result.Path("GameInReplay").GetInt32());
+        }
+
+        [Fact]
+        public void GameState__Paused()
+        {
+            var result = ToR3EDash(NewGt() with { GameState = GameState.Paused });
+
+            Assert.Equal(1, result.Path("GamePaused").GetInt32());
             Assert.Equal(0, result.Path("GameInMenus").GetInt32());
             Assert.Equal(0, result.Path("GameInReplay").GetInt32());
         }
@@ -66,6 +77,7 @@ namespace HUD.Tests.Pipeline
         {
             var result = ToR3EDash(NewGt() with { GameState = GameState.Menu });
 
+            Assert.Equal(0, result.Path("GamePaused").GetInt32());
             Assert.Equal(1, result.Path("GameInMenus").GetInt32());
             Assert.Equal(0, result.Path("GameInReplay").GetInt32());
         }
@@ -75,6 +87,7 @@ namespace HUD.Tests.Pipeline
         {
             var result = ToR3EDash(NewGt() with { GameState = GameState.Replay });
 
+            Assert.Equal(0, result.Path("GamePaused").GetInt32());
             Assert.Equal(0, result.Path("GameInMenus").GetInt32());
             Assert.Equal(1, result.Path("GameInReplay").GetInt32());
         }

--- a/tests/RaceDirector.Tests/Pipeline/DecoupledAcceptanceTest.cs
+++ b/tests/RaceDirector.Tests/Pipeline/DecoupledAcceptanceTest.cs
@@ -109,7 +109,7 @@ namespace RaceDirector.Tests.Pipeline
     {
         public GameState GameState => GameState.Menu;
 
-        public bool UsingVR => false;
+        public bool? UsingVR => null;
 
         public IEvent? Event => null;
 


### PR DESCRIPTION
Relates to #35.

Implements the skeleton for ACC MM telemetry reading. Submitting this as separate PR to allow other work to continue without causing rebase hell.

Additional work:
 - Passing shared data (`struct`) by reference
 - Some style fixes to R3E's code
