### PR TITLE
Logs in dashboard server

### DIFF
--- a/src/Plugins/HUD/HUD.csproj
+++ b/src/Plugins/HUD/HUD.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     <PackageReference Include="NetCoreServer" Version="5.0.15" />
   </ItemGroup>
 

--- a/src/Plugins/HUD/Pipeline/DashboardServer.cs
+++ b/src/Plugins/HUD/Pipeline/DashboardServer.cs
@@ -2,11 +2,8 @@
 using RaceDirector.Plugin.HUD.Server;
 using static RaceDirector.Plugin.HUD.Server.Endpoint;
 using System.Collections.Generic;
-using System.Text.Json;
-using System.IO;
 using System.Net;
-using System;
-using RaceDirector.Plugin.HUD.Utils;
+using Microsoft.Extensions.Logging;
 
 namespace RaceDirector.Plugin.HUD.Pipeline
 {
@@ -15,12 +12,23 @@ namespace RaceDirector.Plugin.HUD.Pipeline
     /// </summary>
     public class DashboardServer : MultiEndpointWsServer<IGameTelemetry>
     {
-        public record Config(IPAddress address, int port = 8070); // TODO remove when config done
+        public record Config(IPAddress Address, int Port = 8070); // TODO remove when config done
 
-        private static readonly IEnumerable<IEndpoint<IGameTelemetry>> _endpoints = new[] {
+        private static readonly IEnumerable<IEndpoint<IGameTelemetry>> DashboardEndpoints = new[] {
             new Endpoint<IGameTelemetry>(PathMatcher("/r3e"), R3EDashTransformer.ToR3EDash)
         };
 
-        public DashboardServer(Config config) : base(config.address, config.port, _endpoints) { }
+        public DashboardServer(ILogger<DashboardServer> logger, Config config) : base(logger, config.Address, config.Port, DashboardEndpoints) { }
+        
+        protected override void OnStarted()
+        {
+            Logger.LogInformation("Dashboard server started");
+        }
+
+        protected override void OnStopped()
+        {
+            Logger.LogInformation("Dashboard server stopped");
+        }
+
     }
 }

--- a/src/Plugins/HUD/Pipeline/WebSocketNodeBase.cs
+++ b/src/Plugins/HUD/Pipeline/WebSocketNodeBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks.Dataflow;
+using RaceDirector.Plugin.HUD.Server;
 
 namespace RaceDirector.Plugin.HUD.Pipeline
 {

--- a/src/Plugins/HUD/Pipeline/WebSocketTelemetryNode.cs
+++ b/src/Plugins/HUD/Pipeline/WebSocketTelemetryNode.cs
@@ -3,6 +3,7 @@ using IRunningGame = RaceDirector.Pipeline.GameMonitor.V0.IRunningGame;
 using System.Threading.Tasks.Dataflow;
 using RaceDirector.Pipeline;
 using System.Collections.Generic;
+using RaceDirector.Plugin.HUD.Server;
 
 namespace RaceDirector.Plugin.HUD.Pipeline
 {

--- a/src/Plugins/HUD/Server/ITcpServer.cs
+++ b/src/Plugins/HUD/Server/ITcpServer.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace RaceDirector.Plugin.HUD.Pipeline
+namespace RaceDirector.Plugin.HUD.Server
 {
     public interface ITcpServer : IDisposable
     {

--- a/src/Plugins/HUD/Server/IWsServer.cs
+++ b/src/Plugins/HUD/Server/IWsServer.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace RaceDirector.Plugin.HUD.Pipeline
+namespace RaceDirector.Plugin.HUD.Server
 {
     public interface IWsServer<T> : ITcpServer
     {

--- a/tests/Plugins/HUD.Tests/Pipeline/DashboardServerTest.cs
+++ b/tests/Plugins/HUD.Tests/Pipeline/DashboardServerTest.cs
@@ -6,6 +6,8 @@ using RaceDirector.Pipeline.Telemetry;
 using RaceDirector.Pipeline.Telemetry.Physics;
 using RaceDirector.Plugin.HUD.Pipeline;
 using System.Net;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace HUD.Tests.Pipeline
@@ -23,7 +25,7 @@ namespace HUD.Tests.Pipeline
         [Fact]
         public void ServesR3ETelemetryEndpoint()
         {
-            using var server = new DashboardServer(new DashboardServer.Config(IPAddress.Any, _serverPort));
+            using var server = new DashboardServer(TestLogger, new DashboardServer.Config(IPAddress.Any, _serverPort));
             Assert.True(server.Start(), "Server did not start");
             using var client = new JsonWsClient(Timeout, _serverPort, "/r3e");
             var telemetry = gtFaker.Generate();
@@ -38,6 +40,7 @@ namespace HUD.Tests.Pipeline
         #region Test setup
 
         private readonly int _serverPort = Tcp.FreePort();
+        private static readonly ILogger<DashboardServer> TestLogger = NullLogger<DashboardServer>.Instance;
 
         #endregion
     }

--- a/tests/Plugins/HUD.Tests/Pipeline/MultiEndpointWsServerTest.cs
+++ b/tests/Plugins/HUD.Tests/Pipeline/MultiEndpointWsServerTest.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Text;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace HUD.Tests.Pipeline
@@ -42,7 +43,7 @@ namespace HUD.Tests.Pipeline
         private void WithServerClient<T>(IEnumerable<IEndpoint<T>> endpoints, string path, Action<IWsServer<T>, JsonWsClient> action)
         {
             var serverPort = Tcp.FreePort();
-            using (var server = new MultiEndpointWsServer<T>(IPAddress.Any, serverPort, endpoints))
+            using (var server = new MultiEndpointWsServer<T>(NullLogger.Instance, IPAddress.Any, serverPort, endpoints))
             {
                 server.Start();
                 using (var client = new JsonWsClient(Timeout, serverPort, path))

--- a/tests/Plugins/HUD.Tests/Pipeline/WebSocketNodeBaseTest.cs
+++ b/tests/Plugins/HUD.Tests/Pipeline/WebSocketNodeBaseTest.cs
@@ -4,6 +4,7 @@ using RaceDirector.Plugin.HUD.Pipeline;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks.Dataflow;
+using RaceDirector.Plugin.HUD.Server;
 using Xunit;
 
 namespace HUD.Tests.Pipeline

--- a/tests/RaceDirector.Tests/Pipeline/GameMonitor/ProcessMonitorNodeTest.cs
+++ b/tests/RaceDirector.Tests/Pipeline/GameMonitor/ProcessMonitorNodeTest.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using Xunit.Categories;
 using RaceDirector.Pipeline.GameMonitor;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 
 namespace RaceDirector.Tests.Pipeline.GameMonitor
@@ -19,7 +20,7 @@ namespace RaceDirector.Tests.Pipeline.GameMonitor
         private static readonly string ProcessName = "RaceDirector.Tests.Ext.Process";
         private static readonly string ProcessArgs = Timeout.Multiply(3).Seconds.ToString();
 
-        private readonly Mock<ILogger<ProcessMonitorNode>> _loggerMock = new();
+        private static readonly ILogger<ProcessMonitorNode> TestLogger = NullLogger<ProcessMonitorNode>.Instance;
 
         [Fact]
         public void OutputGameNameWhenProcessRunning()
@@ -28,7 +29,7 @@ namespace RaceDirector.Tests.Pipeline.GameMonitor
                 new GameProcessInfo(GameName, new[] { ProcessName })
             };
             var config = new ProcessMonitorNode.Config(PollingInterval);
-            var processMonitorNode = new ProcessMonitorNode(_loggerMock.Object, config, gameProcessInfos);
+            var processMonitorNode = new ProcessMonitorNode(TestLogger, config, gameProcessInfos);
             var source = processMonitorNode.RunningGameSource;
             using (new RunningProcess(ProcessName, ProcessArgs))
             {

--- a/tests/RaceDirector.Tests/Pipeline/Telemetry/TelemetryReaderNodeTest.cs
+++ b/tests/RaceDirector.Tests/Pipeline/Telemetry/TelemetryReaderNodeTest.cs
@@ -20,7 +20,7 @@ namespace RaceDirector.Tests.Pipeline.Telemetry
         [Fact]
         public void DoesNotEmitWhenGameNotMatching()
         {
-            var trn = new TelemetryReaderNode(new ITelemetrySourceFactory[0]);
+            var trn = new TelemetryReaderNode(Array.Empty<ITelemetrySourceFactory>());
             trn.RunningGameTarget.Post(new RunningGame(null));
             trn.RunningGameTarget.Post(new RunningGame("any"));
             Assert.Throws<TimeoutException>(() => trn.GameTelemetrySource.Receive(Timeout));


### PR DESCRIPTION
Closes #18.

Example of logs produced at Info level:
```
info: RaceDirector.Pipeline.GameMonitor.ProcessMonitorNode[0]
      Found game R3E (process RRRE64)
info: RaceDirector.Plugin.HUD.Pipeline.DashboardServer[0]
      Dashboard server started
info: RaceDirector.Pipeline.GameMonitor.ProcessMonitorNode[0]
      The game has been closed
info: RaceDirector.Plugin.HUD.Pipeline.DashboardServer[0]
      Dashboard server stopped
```

Logs when Trace is enabled:
```
trce: RaceDirector.Plugin.HUD.Pipeline.DashboardServer[0]
      Sending message GameTelemetry { GameState = Driving, UsingVR = False, Event = , Session = , Vehicles = RaceDirector.Pipeline.Telemetry.Vehicle[], FocusedVehicle = , Player =  }
```

Moved also server classes to the correct namespace.