### PR TITLE
File-scoped namespaces

### DIFF
--- a/src/Plugins/HUD/Pipeline/DashboardServer.cs
+++ b/src/Plugins/HUD/Pipeline/DashboardServer.cs
@@ -5,40 +5,39 @@ using System.Collections.Generic;
 using System.Net;
 using Microsoft.Extensions.Logging;
 
-namespace RaceDirector.Plugin.HUD.Pipeline
+namespace RaceDirector.Plugin.HUD.Pipeline;
+
+/// <summary>
+/// Exposes live telemetry for dashboards.
+/// </summary>
+public class DashboardServer : MultiEndpointWsServer<IGameTelemetry>
 {
-    /// <summary>
-    /// Exposes live telemetry for dashboards.
-    /// </summary>
-    public class DashboardServer : MultiEndpointWsServer<IGameTelemetry>
+    public class Config
     {
-        public class Config
-        {
-            public IPAddress Address { get; set; } = IPAddress.Any;
-            public int Port { get; set; } = 8070;
+        public IPAddress Address { get; set; } = IPAddress.Any;
+        public int Port { get; set; } = 8070;
             
-            public R3EDashTransformer.Configuration R3EDash { get; set; } = new();
-        }
-
-        private static IEnumerable<IEndpoint<IGameTelemetry>> DashboardEndpoints(Config config)
-        {
-            var r3EDashTransformer = new R3EDashTransformer(config.R3EDash);
-            return new[] {
-                new Endpoint<IGameTelemetry>(PathMatcher("/r3e"), r3EDashTransformer.ToR3EDash)
-            };  
-        }
-
-        public DashboardServer(Config config, ILogger<DashboardServer> logger) : base(config.Address, config.Port, DashboardEndpoints(config), logger) { }
-        
-        protected override void OnStarted()
-        {
-            Logger.LogInformation("Dashboard server started");
-        }
-
-        protected override void OnStopped()
-        {
-            Logger.LogInformation("Dashboard server stopped");
-        }
-
+        public R3EDashTransformer.Configuration R3EDash { get; set; } = new();
     }
+
+    private static IEnumerable<IEndpoint<IGameTelemetry>> DashboardEndpoints(Config config)
+    {
+        var r3EDashTransformer = new R3EDashTransformer(config.R3EDash);
+        return new[] {
+            new Endpoint<IGameTelemetry>(PathMatcher("/r3e"), r3EDashTransformer.ToR3EDash)
+        };  
+    }
+
+    public DashboardServer(Config config, ILogger<DashboardServer> logger) : base(config.Address, config.Port, DashboardEndpoints(config), logger) { }
+        
+    protected override void OnStarted()
+    {
+        Logger.LogInformation("Dashboard server started");
+    }
+
+    protected override void OnStopped()
+    {
+        Logger.LogInformation("Dashboard server stopped");
+    }
+
 }

--- a/src/Plugins/HUD/Pipeline/R3EDashTransformer.cs
+++ b/src/Plugins/HUD/Pipeline/R3EDashTransformer.cs
@@ -8,893 +8,892 @@ using RaceDirector.Pipeline.Telemetry;
 using RaceDirector.Pipeline.Telemetry.Physics;
 using System.Text;
 
-namespace RaceDirector.Plugin.HUD.Pipeline
+namespace RaceDirector.Plugin.HUD.Pipeline;
+
+public class R3EDashTransformer
 {
-    public class R3EDashTransformer
+    public class Configuration
     {
-        public class Configuration
-        {
-            public uint MajorVersion { get; set; } = 2;
-            public uint MinorVersion { get; set; } = 11;
-        }
+        public uint MajorVersion { get; set; } = 2;
+        public uint MinorVersion { get; set; } = 11;
+    }
 
-        private static readonly JsonWriterOptions JsonWriterOptions = new();
+    private static readonly JsonWriterOptions JsonWriterOptions = new();
 
-        private readonly Configuration _config;
-        public R3EDashTransformer(Configuration config)
-        {
-            _config = config;
-        }
+    private readonly Configuration _config;
+    public R3EDashTransformer(Configuration config)
+    {
+        _config = config;
+    }
 
-        public byte[] ToR3EDash(IGameTelemetry gt)
+    public byte[] ToR3EDash(IGameTelemetry gt)
+    {
+        using (var stream = new MemoryStream())
         {
-            using (var stream = new MemoryStream())
+            using (var writer = new Utf8JsonWriter(stream, JsonWriterOptions))
             {
-                using (var writer = new Utf8JsonWriter(stream, JsonWriterOptions))
+                WriteR3EDash(writer, gt);
+            }
+            return stream.ToArray();
+        }
+    }
+
+    private void WriteR3EDash(Utf8JsonWriter w, IGameTelemetry gt)
+    {
+        w.WriteObject(_ =>
+        {
+            w.WriteNumber("VersionMajor", _config.MajorVersion);
+            w.WriteNumber("VersionMinor", _config.MinorVersion);
+
+            // AllDriversOffset
+            // DriverDataSize
+
+            w.WriteNumber("GamePaused", gt.Session is null ? -1 : MatchAsInt32(gt.GameState, GameState.Paused));
+            w.WriteNumber("GameInMenus", gt.Session is null ? -1 : MatchAsInt32(gt.GameState, GameState.Menu));
+            w.WriteNumber("GameInReplay", gt.Session is null ? -1 : MatchAsInt32(gt.GameState, GameState.Replay));
+            w.WriteNumber("GameUsingVr", gt.Session is null ? -1 : ToInt32(gt.UsingVR));
+
+            w.WriteObject("Player", _ =>
+            {
+                // Player.GameSimulationTicks
+                // Player.GameSimulationTime
+
+                w.WriteCoordinates("Position", gt.Player?.CgLocation, d => d.M);
+
+                // Player.Velocity.X
+                // Player.Velocity.Y
+                // Player.Velocity.Z
+                // Player.LocalVelocity.X
+                // Player.LocalVelocity.Y
+                // Player.LocalVelocity.Z
+                // Player.Acceleration.X
+                // Player.Acceleration.Y
+                // Player.Acceleration.Z
+
+                w.WriteCoordinates("LocalAcceleration", gt.Player?.LocalAcceleration, a => a.MPS2);
+
+                // Player.Orientation.X
+                // Player.Orientation.Y
+                // Player.Orientation.Z
+                // Player.Rotation.X
+                // Player.Rotation.Y
+                // Player.Rotation.Z
+                // Player.AngularAcceleration.X
+                // Player.AngularAcceleration.Y
+                // Player.AngularAcceleration.Z
+                // Player.AngularVelocity.X
+                // Player.AngularVelocity.Y
+                // Player.AngularVelocity.Z
+                // Player.LocalAngularVelocity.X
+                // Player.LocalAngularVelocity.Y
+                // Player.LocalAngularVelocity.Z
+
+                w.WriteCoordinates("LocalGforce", gt.Player?.LocalAcceleration, a => a.ApproxG);
+
+                // Player.SteeringForce
+                // Player.SteeringForcePercentage
+                // Player.EngineTorque
+                // Player.CurrentDownforce
+                // Player.Voltage
+                // Player.ErsLevel
+                // Player.PowerMguH
+                // Player.PowerMguK
+                // Player.TorqueMguK
+                // Player.SuspensionDeflection.FrontLeft
+                // Player.SuspensionDeflection.FrontRight
+                // Player.SuspensionDeflection.RearLeft
+                // Player.SuspensionDeflection.RearRight
+                // Player.SuspensionVelocity.FrontLeft
+                // Player.SuspensionVelocity.FrontRight
+                // Player.SuspensionVelocity.RearLeft
+                // Player.SuspensionVelocity.RearRight
+                // Player.Camber.FrontLeft
+                // Player.Camber.FrontRight
+                // Player.Camber.RearLeft
+                // Player.Camber.RearRight
+                // Player.RideHeight.FrontLeft
+                // Player.RideHeight.FrontRight
+                // Player.RideHeight.RearLeft
+                // Player.RideHeight.RearRight
+                // Player.FrontWingHeight
+                // Player.FrontRollAngle
+                // Player.RearRollAngle
+                // Player.thirdSpringSuspensionDeflectionFront
+                // Player.thirdSpringSuspensionVelocityFront
+                // Player.thirdSpringSuspensionDeflectionRear
+                // Player.thirdSpringSuspensionVelocityRear
+            });
+
+            // TrackName
+            // LayoutName
+            // TrackId
+            // LayoutId
+
+            w.WriteRoundedNumber("LayoutLength", (gt.Event?.TrackLayout.Length?.M) ?? -1.0);
+
+            w.WriteSectors("SectorStartFactors", gt.Event?.TrackLayout.SectorsEnd, st => st.Fraction);
+
+            // RaceSessionLaps.Race1
+            // RaceSessionLaps.Race2
+            // RaceSessionLaps.Race3
+            // RaceSessionMinutes.Race1
+            // RaceSessionMinutes.Race2
+            // RaceSessionMinutes.Race3
+            // EventIndex
+
+            w.WriteNumber("SessionType", gt.Session?.Type switch
+            {
+                SessionType.Practice => 0,
+                SessionType.Qualify => 1,
+                SessionType.Race => 2,
+                SessionType.Warmup => 3,
+                _ => -1
+            });
+
+            // SessionIteration
+            // SessionLengthFormat
+
+            w.WriteNumber("SessionLengthFormat", gt.Session?.Length switch
+            {
+                TimeDuration => 0,
+                LapsDuration => 1,
+                TimePlusLapsDuration => 2,
+                _ => -1
+            });
+            w.WriteRoundedNumber("SessionPitSpeedLimit", gt.Session?.PitSpeedLimit.MPS ?? -1.0);
+            w.WriteNumber("SessionPhase", gt.Session?.Phase switch
+            {
+                SessionPhase.Garage => 1,
+                SessionPhase.GridWalk => 2,
+                SessionPhase.Formation => 3,
+                SessionPhase.Countdown => 4,
+                SessionPhase.Started => 5,
+                SessionPhase.Over => 6,
+                _ => -1
+            });
+            w.WriteNumber("StartLights", ToInt32(gt.Session?.StartLights));
+
+            // TireWearActive
+            w.WriteNumber("FuelUseActive", Convert.ToInt32(gt.Event?.FuelRate ?? -1));
+
+            w.WriteNumber("NumberOfLaps", gt.Session?.Length switch
+            {
+                LapsDuration length => length.Laps,
+                _ => -1
+            });
+            w.WriteRoundedNumber("SessionTimeDuration", gt.Session?.Length switch
+            {
+                TimeDuration length => length.Time.TotalSeconds,
+                TimePlusLapsDuration length => length.Time.TotalSeconds,
+                _ => -1.0
+            });
+            w.WriteRoundedNumber("SessionTimeRemaining",
+                gt.Session?.WaitTime?.TotalSeconds ??
+                gt.Session?.TimeRemaining?.TotalSeconds ??
+                -1.0
+            );
+
+            // MaxIncidentPoints
+
+            w.WriteNumber("PitWindowStatus", PitWindowStatusAsInt32(gt));
+
+            var pitWindow = PitWindowBoundaries(gt);
+            w.WriteNumber("PitWindowStart", pitWindow.Start);
+            w.WriteNumber("PitWindowEnd", pitWindow.Finish);
+
+            w.WriteNumber("InPitLane", InPitLaneAsInt32(gt.FocusedVehicle));
+
+            // PitMenuSelection
+            // PitMenuState.Preset
+            // PitMenuState.Penalty
+            // PitMenuState.Driverchange
+            // PitMenuState.Fuel
+            // PitMenuState.FrontTires
+            // PitMenuState.RearTires
+            // PitMenuState.FrontWing
+            // PitMenuState.RearWing
+            // PitMenuState.Suspension
+            // PitMenuState.ButtonTop
+            // PitMenuState.ButtonBottom
+
+            w.WriteNumber("PitState", PitStateAsInt32(gt));
+            w.WriteRoundedNumber("PitTotalDuration", gt.FocusedVehicle?.Pit.PitLaneTime?.TotalSeconds ?? -1.0);
+            w.WriteRoundedNumber("PitElapsedTime", gt.FocusedVehicle?.Pit.PitStallTime?.TotalSeconds ?? -1.0);
+            w.WriteNumber("PitAction", PitActionAsInt32(gt.Player));
+
+            // NumPitstopsPerformed
+            // PitMinDurationTotal
+            // PitMinDurationLeft
+
+            w.WriteObject("Flags", _ =>
+            {
+                var raceStarted = gt.Session?.Phase switch
                 {
-                    WriteR3EDash(writer, gt);
+                    SessionPhase.Started => true,
+                    SessionPhase.FullCourseYellow => true,
+                    SessionPhase.Stopped => true,
+                    SessionPhase.Over => true,
+                    _ => false
+                };
+                var focusedVechicleRacing = gt.FocusedVehicle?.RacingStatus == IRacingStatus.Racing; // TODO test
+                var raceOngoing = gt.Session?.Phase switch
+                {
+                    SessionPhase.Started => true,
+                    SessionPhase.FullCourseYellow => true,
+                    SessionPhase.Stopped => true,
+                    SessionPhase.Over => focusedVechicleRacing, // Race is over when the leader crosses the line
+                    _ => false
+                };
+
+                w.WriteNumber("Yellow", ToInt32(gt.FocusedVehicle?.Flags, f => ConditionalFlagAsInt32(f.Yellow, raceOngoing)));
+
+                // Flags.YellowCausedIt
+
+                w.WriteNumber("YellowOvertake", ToInt32(gt.Player?.OvertakeAllowed));
+                w.WriteNumber("YellowPositionsGained", Conditional(ToInt32(gt.Player?.Warnings.GiveBackPositions), raceStarted));
+
+                // Flags.SectorYellow.Sector1
+                // Flags.SectorYellow.Sector2
+                // Flags.SectorYellow.Sector3
+                // Flags.ClosestYellowDistanceIntoTrack
+
+                w.WriteNumber("Blue", ToInt32(gt.FocusedVehicle?.Flags, f => ConditionalFlagAsInt32(f.Blue, raceOngoing)));
+                w.WriteNumber("Black", ToInt32(gt.FocusedVehicle?.Flags, f => FlagAsInt32(f.Black)));
+                w.WriteNumber("Green", ToInt32(gt.FocusedVehicle?.Flags, f => ConditionalFlagAsInt32(f.Green, raceOngoing)));
+                w.WriteNumber("Checkered", ToInt32(gt.FocusedVehicle?.Flags, f => FlagAsInt32(f.Checkered)));
+                w.WriteNumber("White", ToInt32(gt.FocusedVehicle?.Flags, f => ConditionalFlagAsInt32(f.White, raceOngoing)));
+                w.WriteNumber("BlackAndWhite", ToInt32(gt.FocusedVehicle?.Flags,
+                    f => BlackWhiteFlagAsInt32(f.BlackWhite, gt.Player?.Warnings.BlueFlagWarnings?.Value, raceOngoing)
+                ));
+            });
+
+            // Position
+
+            w.WriteNumber("PositionClass", ToInt32(gt.FocusedVehicle?.PositionClass));
+
+            // FinishStatus
+            // CutTrackWarnings
+
+            w.WriteObject("Penalties", _ =>
+            {
+                var penalties = gt.FocusedVehicle?.Penalties;
+                var initValue = penalties is null ? -1 : 0;
+                var driveThrough = initValue;
+                var stopAndGo = initValue;
+                var pitStop = initValue;
+                var timeDeduction = initValue;
+                var slowDown = initValue;
+                foreach (var p in penalties ?? Array.Empty<IPenalty>())
+                {
+                    switch (p.Type)
+                    {
+                        case PenaltyType.DriveThrough:
+                            driveThrough = 1;
+                            break;
+                        case PenaltyType.StopAndGo10:
+                        case PenaltyType.StopAndGo20:
+                        case PenaltyType.StopAndGo30:
+                            stopAndGo = 1;
+                            break;
+                        case PenaltyType.PitStop:
+                            pitStop = 1;
+                            break;
+                        case PenaltyType.TimeDeduction:
+                            timeDeduction = 1;
+                            break;
+                        case PenaltyType.SlowDown:
+                            slowDown = 1;
+                            break;
+                    }
                 }
-                return stream.ToArray();
-            }
-        }
 
-        private void WriteR3EDash(Utf8JsonWriter w, IGameTelemetry gt)
-        {
-            w.WriteObject(_ =>
+                w.WriteNumber("DriveThrough", driveThrough);
+                w.WriteNumber("StopAndGo", stopAndGo);
+                w.WriteNumber("PitStop", pitStop);
+                w.WriteNumber("TimeDeduction", timeDeduction);
+                w.WriteNumber("SlowDown", slowDown);
+            });
+
+            // NumPenalties
+
+            w.WriteNumber("CompletedLaps", ToInt32(gt.FocusedVehicle?.CompletedLaps));
+            w.WriteNumber("CurrentLapValid", gt.FocusedVehicle?.LapValid switch
             {
-                w.WriteNumber("VersionMajor", _config.MajorVersion);
-                w.WriteNumber("VersionMinor", _config.MinorVersion);
+                LapValidState.Invalid => 0,
+                LapValidState.Valid => 1,
+                _ => -1
+            });
 
-                // AllDriversOffset
-                // DriverDataSize
+            // TrackSector
 
-                w.WriteNumber("GamePaused", gt.Session is null ? -1 : MatchAsInt32(gt.GameState, GameState.Paused));
-                w.WriteNumber("GameInMenus", gt.Session is null ? -1 : MatchAsInt32(gt.GameState, GameState.Menu));
-                w.WriteNumber("GameInReplay", gt.Session is null ? -1 : MatchAsInt32(gt.GameState, GameState.Replay));
-                w.WriteNumber("GameUsingVr", gt.Session is null ? -1 : ToInt32(gt.UsingVR));
+            w.WriteRoundedNumber("LapDistance", gt.FocusedVehicle?.CurrentLapDistance.Value.M ?? -1.0);
+            w.WriteRoundedNumber("LapDistanceFraction", gt.FocusedVehicle?.CurrentLapDistance.Fraction ?? -1.0);
 
-                w.WriteObject("Player", _ =>
+            // LapTimeBestLeader
+            // LapTimeBestLeaderClass
+            // SectorTimesSessionBestLap.Sector1
+            // SectorTimesSessionBestLap.Sector2
+            // SectorTimesSessionBestLap.Sector3
+
+            w.WriteRoundedNumber("LapTimeBestSelf", gt.FocusedVehicle?.BestLapTime?.Overall.TotalSeconds ?? -1.0);
+            w.WriteSectors("SectorTimesBestSelf", gt.FocusedVehicle?.BestLapTime?.Sectors.Cumulative, st => st.TotalSeconds);
+
+            // LapTimePreviousSelf
+            // SectorTimesPreviousSelf.Sector1
+            // SectorTimesPreviousSelf.Sector2
+            // SectorTimesPreviousSelf.Sector3
+
+            w.WriteRoundedNumber("LapTimeCurrentSelf", gt.FocusedVehicle?.CurrentLapTime?.Overall.TotalSeconds ?? -1.0);
+            w.WriteSectors("SectorTimesCurrentSelf", gt.FocusedVehicle?.CurrentLapTime?.Sectors.Cumulative, st => st.TotalSeconds);
+
+            // LapTimeDeltaLeader
+            // LapTimeDeltaLeaderClass
+            // TimeDeltaFront => Player or -1.0
+            // TimeDeltaBehind => Player or -1.0
+
+            w.WriteRoundedNumber("TimeDeltaBestSelf", gt.Player?.PersonalBestDelta?.TotalSeconds ?? -1000.0);
+
+            w.WriteSectors("BestIndividualSectorTimeSelf", gt.Player?.PersonalBestSectors?.Individual, st => st.TotalSeconds);
+
+            // BestIndividualSectorTimeLeader.Sector1
+            // BestIndividualSectorTimeLeader.Sector2
+            // BestIndividualSectorTimeLeader.Sector3
+
+            w.WriteSectors("BestIndividualSectorTimeLeaderClass", gt.Player?.ClassBestSectors?.Individual, st => st.TotalSeconds);
+
+            // IncidentPoints
+
+            w.WriteObject("VehicleInfo", _ =>
+            {
+                // VehicleInfo.Name
+                // VehicleInfo.CarNumber
+                // VehicleInfo.ClassId
+                // VehicleInfo.ModelId
+                // VehicleInfo.TeamId
+                // VehicleInfo.LiveryId
+                // VehicleInfo.ManufacturerId
+                // VehicleInfo.UserId
+
+                w.WriteNumber("SlotId", ToInt32(gt.FocusedVehicle?.Id));
+                w.WriteNumber("ClassPerformanceIndex", gt.FocusedVehicle?.ClassPerformanceIndex ?? -1);
+                w.WriteNumber("EngineType", gt.FocusedVehicle?.EngineType switch
                 {
-                    // Player.GameSimulationTicks
-                    // Player.GameSimulationTime
-
-                    w.WriteCoordinates("Position", gt.Player?.CgLocation, d => d.M);
-
-                    // Player.Velocity.X
-                    // Player.Velocity.Y
-                    // Player.Velocity.Z
-                    // Player.LocalVelocity.X
-                    // Player.LocalVelocity.Y
-                    // Player.LocalVelocity.Z
-                    // Player.Acceleration.X
-                    // Player.Acceleration.Y
-                    // Player.Acceleration.Z
-
-                    w.WriteCoordinates("LocalAcceleration", gt.Player?.LocalAcceleration, a => a.MPS2);
-
-                    // Player.Orientation.X
-                    // Player.Orientation.Y
-                    // Player.Orientation.Z
-                    // Player.Rotation.X
-                    // Player.Rotation.Y
-                    // Player.Rotation.Z
-                    // Player.AngularAcceleration.X
-                    // Player.AngularAcceleration.Y
-                    // Player.AngularAcceleration.Z
-                    // Player.AngularVelocity.X
-                    // Player.AngularVelocity.Y
-                    // Player.AngularVelocity.Z
-                    // Player.LocalAngularVelocity.X
-                    // Player.LocalAngularVelocity.Y
-                    // Player.LocalAngularVelocity.Z
-
-                    w.WriteCoordinates("LocalGforce", gt.Player?.LocalAcceleration, a => a.ApproxG);
-
-                    // Player.SteeringForce
-                    // Player.SteeringForcePercentage
-                    // Player.EngineTorque
-                    // Player.CurrentDownforce
-                    // Player.Voltage
-                    // Player.ErsLevel
-                    // Player.PowerMguH
-                    // Player.PowerMguK
-                    // Player.TorqueMguK
-                    // Player.SuspensionDeflection.FrontLeft
-                    // Player.SuspensionDeflection.FrontRight
-                    // Player.SuspensionDeflection.RearLeft
-                    // Player.SuspensionDeflection.RearRight
-                    // Player.SuspensionVelocity.FrontLeft
-                    // Player.SuspensionVelocity.FrontRight
-                    // Player.SuspensionVelocity.RearLeft
-                    // Player.SuspensionVelocity.RearRight
-                    // Player.Camber.FrontLeft
-                    // Player.Camber.FrontRight
-                    // Player.Camber.RearLeft
-                    // Player.Camber.RearRight
-                    // Player.RideHeight.FrontLeft
-                    // Player.RideHeight.FrontRight
-                    // Player.RideHeight.RearLeft
-                    // Player.RideHeight.RearRight
-                    // Player.FrontWingHeight
-                    // Player.FrontRollAngle
-                    // Player.RearRollAngle
-                    // Player.thirdSpringSuspensionDeflectionFront
-                    // Player.thirdSpringSuspensionVelocityFront
-                    // Player.thirdSpringSuspensionDeflectionRear
-                    // Player.thirdSpringSuspensionVelocityRear
+                    EngineType.Combustion => 0,
+                    EngineType.Electric => 1,
+                    EngineType.Hybrid => 2,
+                    _ => 3 // !!!
                 });
+            });
 
-                // TrackName
-                // LayoutName
-                // TrackId
-                // LayoutId
+            // NOTE it is the current vehicle's driver name rather than player name!
+            w.WriteBase64String("PlayerName", NullTerminated(gt.FocusedVehicle?.CurrentDriver.Name));
 
-                w.WriteRoundedNumber("LayoutLength", (gt.Event?.TrackLayout.Length?.M) ?? -1.0);
+            w.WriteNumber("ControlType", gt.FocusedVehicle?.ControlType switch
+            {
+                ControlType.LocalPlayer => 0,
+                ControlType.AI => 1,
+                ControlType.RemotePlayer => 2,
+                ControlType.Replay => 3,
+                _ => -1
+            });
 
-                w.WriteSectors("SectorStartFactors", gt.Event?.TrackLayout.SectorsEnd, st => st.Fraction);
-
-                // RaceSessionLaps.Race1
-                // RaceSessionLaps.Race2
-                // RaceSessionLaps.Race3
-                // RaceSessionMinutes.Race1
-                // RaceSessionMinutes.Race2
-                // RaceSessionMinutes.Race3
-                // EventIndex
-
-                w.WriteNumber("SessionType", gt.Session?.Type switch
-                {
-                    SessionType.Practice => 0,
-                    SessionType.Qualify => 1,
-                    SessionType.Race => 2,
-                    SessionType.Warmup => 3,
-                    _ => -1
-                });
-
-                // SessionIteration
-                // SessionLengthFormat
-
-                w.WriteNumber("SessionLengthFormat", gt.Session?.Length switch
-                {
-                    TimeDuration => 0,
-                    LapsDuration => 1,
-                    TimePlusLapsDuration => 2,
-                    _ => -1
-                });
-                w.WriteRoundedNumber("SessionPitSpeedLimit", gt.Session?.PitSpeedLimit.MPS ?? -1.0);
-                w.WriteNumber("SessionPhase", gt.Session?.Phase switch
-                {
-                    SessionPhase.Garage => 1,
-                    SessionPhase.GridWalk => 2,
-                    SessionPhase.Formation => 3,
-                    SessionPhase.Countdown => 4,
-                    SessionPhase.Started => 5,
-                    SessionPhase.Over => 6,
-                    _ => -1
-                });
-                w.WriteNumber("StartLights", ToInt32(gt.Session?.StartLights));
-
-                // TireWearActive
-                w.WriteNumber("FuelUseActive", Convert.ToInt32(gt.Event?.FuelRate ?? -1));
-
-                w.WriteNumber("NumberOfLaps", gt.Session?.Length switch
-                {
-                    LapsDuration length => length.Laps,
-                    _ => -1
-                });
-                w.WriteRoundedNumber("SessionTimeDuration", gt.Session?.Length switch
-                {
-                    TimeDuration length => length.Time.TotalSeconds,
-                    TimePlusLapsDuration length => length.Time.TotalSeconds,
-                    _ => -1.0
-                });
-                w.WriteRoundedNumber("SessionTimeRemaining",
-                    gt.Session?.WaitTime?.TotalSeconds ??
-                    gt.Session?.TimeRemaining?.TotalSeconds ??
-                    -1.0
-                );
-
-                // MaxIncidentPoints
-
-                w.WriteNumber("PitWindowStatus", PitWindowStatusAsInt32(gt));
-
-                var pitWindow = PitWindowBoundaries(gt);
-                w.WriteNumber("PitWindowStart", pitWindow.Start);
-                w.WriteNumber("PitWindowEnd", pitWindow.Finish);
-
-                w.WriteNumber("InPitLane", InPitLaneAsInt32(gt.FocusedVehicle));
-
-                // PitMenuSelection
-                // PitMenuState.Preset
-                // PitMenuState.Penalty
-                // PitMenuState.Driverchange
-                // PitMenuState.Fuel
-                // PitMenuState.FrontTires
-                // PitMenuState.RearTires
-                // PitMenuState.FrontWing
-                // PitMenuState.RearWing
-                // PitMenuState.Suspension
-                // PitMenuState.ButtonTop
-                // PitMenuState.ButtonBottom
-
-                w.WriteNumber("PitState", PitStateAsInt32(gt));
-                w.WriteRoundedNumber("PitTotalDuration", gt.FocusedVehicle?.Pit.PitLaneTime?.TotalSeconds ?? -1.0);
-                w.WriteRoundedNumber("PitElapsedTime", gt.FocusedVehicle?.Pit.PitStallTime?.TotalSeconds ?? -1.0);
-                w.WriteNumber("PitAction", PitActionAsInt32(gt.Player));
-
-                // NumPitstopsPerformed
-                // PitMinDurationTotal
-                // PitMinDurationLeft
-
-                w.WriteObject("Flags", _ =>
-                {
-                    var raceStarted = gt.Session?.Phase switch
-                    {
-                        SessionPhase.Started => true,
-                        SessionPhase.FullCourseYellow => true,
-                        SessionPhase.Stopped => true,
-                        SessionPhase.Over => true,
-                        _ => false
-                    };
-                    var focusedVechicleRacing = gt.FocusedVehicle?.RacingStatus == IRacingStatus.Racing; // TODO test
-                    var raceOngoing = gt.Session?.Phase switch
-                    {
-                        SessionPhase.Started => true,
-                        SessionPhase.FullCourseYellow => true,
-                        SessionPhase.Stopped => true,
-                        SessionPhase.Over => focusedVechicleRacing, // Race is over when the leader crosses the line
-                        _ => false
-                    };
-
-                    w.WriteNumber("Yellow", ToInt32(gt.FocusedVehicle?.Flags, f => ConditionalFlagAsInt32(f.Yellow, raceOngoing)));
-
-                    // Flags.YellowCausedIt
-
-                    w.WriteNumber("YellowOvertake", ToInt32(gt.Player?.OvertakeAllowed));
-                    w.WriteNumber("YellowPositionsGained", Conditional(ToInt32(gt.Player?.Warnings.GiveBackPositions), raceStarted));
-
-                    // Flags.SectorYellow.Sector1
-                    // Flags.SectorYellow.Sector2
-                    // Flags.SectorYellow.Sector3
-                    // Flags.ClosestYellowDistanceIntoTrack
-
-                    w.WriteNumber("Blue", ToInt32(gt.FocusedVehicle?.Flags, f => ConditionalFlagAsInt32(f.Blue, raceOngoing)));
-                    w.WriteNumber("Black", ToInt32(gt.FocusedVehicle?.Flags, f => FlagAsInt32(f.Black)));
-                    w.WriteNumber("Green", ToInt32(gt.FocusedVehicle?.Flags, f => ConditionalFlagAsInt32(f.Green, raceOngoing)));
-                    w.WriteNumber("Checkered", ToInt32(gt.FocusedVehicle?.Flags, f => FlagAsInt32(f.Checkered)));
-                    w.WriteNumber("White", ToInt32(gt.FocusedVehicle?.Flags, f => ConditionalFlagAsInt32(f.White, raceOngoing)));
-                    w.WriteNumber("BlackAndWhite", ToInt32(gt.FocusedVehicle?.Flags,
-                        f => BlackWhiteFlagAsInt32(f.BlackWhite, gt.Player?.Warnings.BlueFlagWarnings?.Value, raceOngoing)
-                    ));
-                });
-
-                // Position
-
-                w.WriteNumber("PositionClass", ToInt32(gt.FocusedVehicle?.PositionClass));
-
-                // FinishStatus
-                // CutTrackWarnings
-
-                w.WriteObject("Penalties", _ =>
-                {
-                    var penalties = gt.FocusedVehicle?.Penalties;
-                    var initValue = penalties is null ? -1 : 0;
-                    var driveThrough = initValue;
-                    var stopAndGo = initValue;
-                    var pitStop = initValue;
-                    var timeDeduction = initValue;
-                    var slowDown = initValue;
-                    foreach (var p in penalties ?? Array.Empty<IPenalty>())
-                    {
-                        switch (p.Type)
-                        {
-                            case PenaltyType.DriveThrough:
-                                driveThrough = 1;
-                                break;
-                            case PenaltyType.StopAndGo10:
-                            case PenaltyType.StopAndGo20:
-                            case PenaltyType.StopAndGo30:
-                                stopAndGo = 1;
-                                break;
-                            case PenaltyType.PitStop:
-                                pitStop = 1;
-                                break;
-                            case PenaltyType.TimeDeduction:
-                                timeDeduction = 1;
-                                break;
-                            case PenaltyType.SlowDown:
-                                slowDown = 1;
-                                break;
-                        }
-                    }
-
-                    w.WriteNumber("DriveThrough", driveThrough);
-                    w.WriteNumber("StopAndGo", stopAndGo);
-                    w.WriteNumber("PitStop", pitStop);
-                    w.WriteNumber("TimeDeduction", timeDeduction);
-                    w.WriteNumber("SlowDown", slowDown);
-                });
-
-                // NumPenalties
-
-                w.WriteNumber("CompletedLaps", ToInt32(gt.FocusedVehicle?.CompletedLaps));
-                w.WriteNumber("CurrentLapValid", gt.FocusedVehicle?.LapValid switch
-                {
-                    LapValidState.Invalid => 0,
-                    LapValidState.Valid => 1,
-                    _ => -1
-                });
-
-                // TrackSector
-
-                w.WriteRoundedNumber("LapDistance", gt.FocusedVehicle?.CurrentLapDistance.Value.M ?? -1.0);
-                w.WriteRoundedNumber("LapDistanceFraction", gt.FocusedVehicle?.CurrentLapDistance.Fraction ?? -1.0);
-
-                // LapTimeBestLeader
-                // LapTimeBestLeaderClass
-                // SectorTimesSessionBestLap.Sector1
-                // SectorTimesSessionBestLap.Sector2
-                // SectorTimesSessionBestLap.Sector3
-
-                w.WriteRoundedNumber("LapTimeBestSelf", gt.FocusedVehicle?.BestLapTime?.Overall.TotalSeconds ?? -1.0);
-                w.WriteSectors("SectorTimesBestSelf", gt.FocusedVehicle?.BestLapTime?.Sectors.Cumulative, st => st.TotalSeconds);
-
-                // LapTimePreviousSelf
-                // SectorTimesPreviousSelf.Sector1
-                // SectorTimesPreviousSelf.Sector2
-                // SectorTimesPreviousSelf.Sector3
-
-                w.WriteRoundedNumber("LapTimeCurrentSelf", gt.FocusedVehicle?.CurrentLapTime?.Overall.TotalSeconds ?? -1.0);
-                w.WriteSectors("SectorTimesCurrentSelf", gt.FocusedVehicle?.CurrentLapTime?.Sectors.Cumulative, st => st.TotalSeconds);
-
-                // LapTimeDeltaLeader
-                // LapTimeDeltaLeaderClass
-                // TimeDeltaFront => Player or -1.0
-                // TimeDeltaBehind => Player or -1.0
-
-                w.WriteRoundedNumber("TimeDeltaBestSelf", gt.Player?.PersonalBestDelta?.TotalSeconds ?? -1000.0);
-
-                w.WriteSectors("BestIndividualSectorTimeSelf", gt.Player?.PersonalBestSectors?.Individual, st => st.TotalSeconds);
-
-                // BestIndividualSectorTimeLeader.Sector1
-                // BestIndividualSectorTimeLeader.Sector2
-                // BestIndividualSectorTimeLeader.Sector3
-
-                w.WriteSectors("BestIndividualSectorTimeLeaderClass", gt.Player?.ClassBestSectors?.Individual, st => st.TotalSeconds);
-
-                // IncidentPoints
-
-                w.WriteObject("VehicleInfo", _ =>
-                {
-                    // VehicleInfo.Name
-                    // VehicleInfo.CarNumber
-                    // VehicleInfo.ClassId
-                    // VehicleInfo.ModelId
-                    // VehicleInfo.TeamId
-                    // VehicleInfo.LiveryId
-                    // VehicleInfo.ManufacturerId
-                    // VehicleInfo.UserId
-
-                    w.WriteNumber("SlotId", ToInt32(gt.FocusedVehicle?.Id));
-                    w.WriteNumber("ClassPerformanceIndex", gt.FocusedVehicle?.ClassPerformanceIndex ?? -1);
-                    w.WriteNumber("EngineType", gt.FocusedVehicle?.EngineType switch
-                    {
-                        EngineType.Combustion => 0,
-                        EngineType.Electric => 1,
-                        EngineType.Hybrid => 2,
-                        _ => 3 // !!!
-                    });
-                });
-
-                // NOTE it is the current vehicle's driver name rather than player name!
-                w.WriteBase64String("PlayerName", NullTerminated(gt.FocusedVehicle?.CurrentDriver.Name));
-
-                w.WriteNumber("ControlType", gt.FocusedVehicle?.ControlType switch
-                {
-                    ControlType.LocalPlayer => 0,
-                    ControlType.AI => 1,
-                    ControlType.RemotePlayer => 2,
-                    ControlType.Replay => 3,
-                    _ => -1
-                });
-
-                w.WriteRoundedNumber("CarSpeed", gt.FocusedVehicle?.Speed.MPS ?? -1.0);
+            w.WriteRoundedNumber("CarSpeed", gt.FocusedVehicle?.Speed.MPS ?? -1.0);
                 
-                w.WriteRoundedNumber("EngineRps", gt.Player?.Engine.Speed.RadPS ?? -1.0);
-                w.WriteRoundedNumber("MaxEngineRps", gt.Player?.Engine.MaxSpeed.RadPS ?? -1.0);
-                w.WriteRoundedNumber("UpshiftRps", gt.Player?.Engine.UpshiftSpeed.RadPS ?? -1.0);
+            w.WriteRoundedNumber("EngineRps", gt.Player?.Engine.Speed.RadPS ?? -1.0);
+            w.WriteRoundedNumber("MaxEngineRps", gt.Player?.Engine.MaxSpeed.RadPS ?? -1.0);
+            w.WriteRoundedNumber("UpshiftRps", gt.Player?.Engine.UpshiftSpeed.RadPS ?? -1.0);
 
-                // Gear
-                // NumGears
+            // Gear
+            // NumGears
 
-                w.WriteCoordinates("CarCgLocation", gt.FocusedVehicle?.Location, d => d.M);
+            w.WriteCoordinates("CarCgLocation", gt.FocusedVehicle?.Location, d => d.M);
 
-                w.WriteOrientationPyr("CarOrientation", gt.FocusedVehicle?.Orientation, a => a.Rad);
+            w.WriteOrientationPyr("CarOrientation", gt.FocusedVehicle?.Orientation, a => a.Rad);
 
-                // LocalAcceleration.X
-                // LocalAcceleration.Y
-                // LocalAcceleration.Z
-                // TotalMass
+            // LocalAcceleration.X
+            // LocalAcceleration.Y
+            // LocalAcceleration.Z
+            // TotalMass
 
-                w.WriteRoundedNumber("FuelLeft", gt.Player?.Fuel.Left ?? -1.0);
-                w.WriteRoundedNumber("FuelCapacity", gt.Player?.Fuel.Max ?? -1.0);
-                w.WriteRoundedNumber("FuelPerLap", gt.Player?.Fuel.PerLap ?? -1.0);
+            w.WriteRoundedNumber("FuelLeft", gt.Player?.Fuel.Left ?? -1.0);
+            w.WriteRoundedNumber("FuelCapacity", gt.Player?.Fuel.Max ?? -1.0);
+            w.WriteRoundedNumber("FuelPerLap", gt.Player?.Fuel.PerLap ?? -1.0);
 
-                // EngineWaterTemp
-                // EngineOilTemp
-                // FuelPressure
-                // EngineOilPressure
-                // TurboPressure
+            // EngineWaterTemp
+            // EngineOilTemp
+            // FuelPressure
+            // EngineOilPressure
+            // TurboPressure
 
-                w.WriteRoundedNumber("Throttle", gt.FocusedVehicle?.Inputs?.Throttle ?? -1.0);
-                w.WriteRoundedNumber("ThrottleRaw", gt.Player?.RawInputs.Throttle ?? -1.0);
-                w.WriteRoundedNumber("Brake", gt.FocusedVehicle?.Inputs?.Brake ?? -1.0);
-                w.WriteRoundedNumber("BrakeRaw", gt.Player?.RawInputs.Brake ?? -1.0);
-                w.WriteRoundedNumber("Clutch", gt.FocusedVehicle?.Inputs?.Clutch ?? -1.0);
-                w.WriteRoundedNumber("ClutchRaw", gt.Player?.RawInputs.Clutch ?? -1.0);
-                w.WriteRoundedNumber("SteerInputRaw", gt.Player?.RawInputs.Steering ?? 0.0);
+            w.WriteRoundedNumber("Throttle", gt.FocusedVehicle?.Inputs?.Throttle ?? -1.0);
+            w.WriteRoundedNumber("ThrottleRaw", gt.Player?.RawInputs.Throttle ?? -1.0);
+            w.WriteRoundedNumber("Brake", gt.FocusedVehicle?.Inputs?.Brake ?? -1.0);
+            w.WriteRoundedNumber("BrakeRaw", gt.Player?.RawInputs.Brake ?? -1.0);
+            w.WriteRoundedNumber("Clutch", gt.FocusedVehicle?.Inputs?.Clutch ?? -1.0);
+            w.WriteRoundedNumber("ClutchRaw", gt.Player?.RawInputs.Clutch ?? -1.0);
+            w.WriteRoundedNumber("SteerInputRaw", gt.Player?.RawInputs.Steering ?? 0.0);
 
-                // SteerLockDegrees
+            // SteerLockDegrees
 
-                w.WriteNumber("SteerWheelRangeDegrees", ToUInt32(gt.Player?.RawInputs.SteerWheelRange.Deg));
+            w.WriteNumber("SteerWheelRangeDegrees", ToUInt32(gt.Player?.RawInputs.SteerWheelRange.Deg));
 
-                w.WriteObject("AidSettings", _ =>
-                {
-                    w.WriteNumber("Abs", ToInt32(gt.Player?.DrivingAids.Abs));
-                    w.WriteNumber("Tc", ToInt32(gt.Player?.DrivingAids.Tc));
-                    w.WriteNumber("Esp", ToInt32(gt.Player?.DrivingAids.Esp));
-                    w.WriteNumber("Countersteer", ToInt32(gt.Player?.DrivingAids.Countersteer));
-                    w.WriteNumber("Cornering", ToInt32(gt.Player?.DrivingAids.Cornering));
-                });
-
-                w.WriteObject("Drs", _ =>
-                {
-                    if (gt.Player is null)
-                    {
-                        w.WriteNumber("Equipped", -1);
-                        w.WriteNumber("Available", -1);
-                        w.WriteNumber("NumActivationsLeft", -1);
-                        w.WriteNumber("Engaged", -1);
-                    }
-                    else if (gt.Player.Drs is null)
-                    {
-                        w.WriteNumber("Equipped", 0);
-                        w.WriteNumber("Available", 0);
-                        w.WriteNumber("NumActivationsLeft", 0);
-                        w.WriteNumber("Engaged", 0);
-                    }
-                    else
-                    {
-                        w.WriteNumber("Equipped", 1);
-                        w.WriteNumber("Available", gt.Player.Drs.Available ? 1 : 0);
-                        w.WriteNumber("NumActivationsLeft", ToInt32(gt.Player.Drs.ActivationsLeft?.Value));
-                        w.WriteNumber("Engaged", gt.Player.Drs.Engaged ? 1 : 0);
-                    }
-                });
-
-                // PitLimiter
-
-                w.WriteObject("PushToPass", _ =>
-                {
-                    w.WriteNumber("Available", ToInt32(gt.Player?.PushToPass?.Available));
-                    w.WriteNumber("Engaged", ToInt32(gt.Player?.PushToPass?.Engaged));
-                    w.WriteNumber("AmountLeft", ToInt32(gt.Player?.PushToPass?.ActivationsLeft?.Value));
-                    w.WriteRoundedNumber("EngagedTimeLeft", gt.Player?.PushToPass?.EngagedTimeLeft.TotalSeconds ?? -1.0); // not sure
-                    w.WriteRoundedNumber("WaitTimeLeft", gt.Player?.PushToPass?.WaitTimeLeft.TotalSeconds ?? -1.0); // not sure
-                });
-
-                // BrakeBias
-
-                w.WriteNumber("DrsNumActivationsTotal", ToInt32(gt.Player?.Drs?.ActivationsLeft?.Total));
-                w.WriteNumber("PtPNumActivationsTotal", ToInt32(gt.Player?.PushToPass?.ActivationsLeft?.Total)); // ********************** is this per lap?!?!?!?!?!?
-
-                // TireType
-                // TireRps.FrontLeft
-                // TireRps.FrontRight
-                // TireRps.RearLeft
-                // TireRps.RearRight
-                // TireSpeed.FrontLeft
-                // TireSpeed.FrontRight
-                // TireSpeed.RearLeft
-                // TireSpeed.RearRight
-
-                w.WriteObject("TireGrip", _ =>
-                {
-                    ForEachTire(gt.Player?.Tires, (tireName, tire) =>
-                    {
-                        w.WriteRoundedNumber(tireName, tire?.Grip ?? -1.0);
-                    });
-                });
-
-                w.WriteObject("TireWear", _ =>
-                {
-                    ForEachTire(gt.Player?.Tires, (tireName, tire) =>
-                    {
-                        w.WriteRoundedNumber(tireName, tire?.Wear ?? -1.0);
-                    });
-                });
-
-                // TireFlatspot.FrontLeft
-                // TireFlatspot.FrontRight
-                // TireFlatspot.RearLeft
-                // TireFlatspot.RearRight
-                // TirePressure.FrontLeft
-                // TirePressure.FrontRight
-                // TirePressure.RearLeft
-                // TirePressure.RearRight
-
-                w.WriteObject("TireDirt", _ =>
-                {
-                    ForEachTire(gt.Player?.Tires, (tireName, tire) =>
-                    {
-                        w.WriteRoundedNumber(tireName, tire?.Dirt ?? -1.0);
-                    });
-                });
-
-                w.WriteObject("TireTemp", _ =>
-                {
-                    ForEachTire(gt.Player?.Tires, (tireName, tire) =>
-                    {
-                        w.WriteObject(tireName, _ =>
-                        {
-                            var temperatures = tire?.Temperatures;
-                            w.WriteObject("CurrentTemp", _ =>
-                            {
-                                var currentTemperatures = temperatures?.CurrentTemperatures;
-                                w.WriteRoundedNumber("Left", currentTemperatures?.GetValueOrNull(0, 0)?.C ?? -1.0);
-                                w.WriteRoundedNumber("Center", currentTemperatures?.GetValueOrNull(0, 1)?.C ?? -1.0);
-                                w.WriteRoundedNumber("Right", currentTemperatures?.GetValueOrNull(0, 2)?.C ?? -1.0);
-                            });
-                            w.WriteRoundedNumber("OptimalTemp", temperatures?.OptimalTemperature.C ?? -1.0);
-                            w.WriteRoundedNumber("ColdTemp", temperatures?.ColdTemperature.C ?? -1.0);
-                            w.WriteRoundedNumber("HotTemp", temperatures?.HotTemperature.C ?? -1.0);
-                        });
-                    });
-                });
-
-                // TireTypeFront
-                // TireTypeRear
-                // TireSubtypeFront
-                // TireSubtypeRear
-
-                w.WriteObject("BrakeTemp", _ =>
-                {
-                    ForEachTire(gt.Player?.Tires, (tireName, tire) =>
-                    {
-                        w.WriteObject(tireName, _ =>
-                        {
-                            w.WriteRoundedNumber("CurrentTemp", tire?.BrakeTemperatures.CurrentTemperature.C ?? -1.0);
-                            w.WriteRoundedNumber("OptimalTemp", tire?.BrakeTemperatures.OptimalTemperature.C ?? - 1.0);
-                            w.WriteRoundedNumber("ColdTemp", tire?.BrakeTemperatures.ColdTemperature.C ?? - 1.0);
-                            w.WriteRoundedNumber("HotTemp", tire?.BrakeTemperatures.HotTemperature.C ?? - 1.0);
-                        });
-                    });
-                });
-
-                // BrakePressure.FrontLeft
-                // BrakePressure.FrontRight
-                // BrakePressure.RearLeft
-                // BrakePressure.RearRight
-                // TractionControlSetting
-                // EngineMapSetting
-                // EngineBrakeSetting
-                // TireLoad.FrontLeft
-                // TireLoad.FrontRight
-                // TireLoad.RearLeft
-                // TireLoad.RearRight
-
-                w.WriteObject("CarDamage", _ =>
-                {
-                    w.WriteRoundedNumber("Engine", gt.Player?.VehicleDamage.EnginePercent ?? -1.0);
-                    w.WriteRoundedNumber("Transmission", gt.Player?.VehicleDamage.TransmissionPercent ?? -1.0);
-                    w.WriteRoundedNumber("Aerodynamics", gt.Player?.VehicleDamage.AerodynamicsPercent ?? -1.0);
-                    w.WriteRoundedNumber("Suspension", gt.Player?.VehicleDamage.SuspensionPercent ?? -1.0);
-                });
-
-                // NumCars
-
-                // Note: Sometimes there's a lot of "null" vehicles after NumCars, but we won't render them.
-                w.WriteArray("DriverData", _ =>
-                {
-                    foreach (var vehicle in gt.Vehicles)
-                    {
-                        w.WriteObject(_ =>
-                        {
-                            w.WriteObject("DriverInfo", _ =>
-                            {
-                                w.WriteBase64String("Name", NullTerminated(vehicle.CurrentDriver.Name));
-
-                                // DriverData[].DriverInfo.CarNumber
-                                // DriverData[].DriverInfo.ClassId
-                                // DriverData[].DriverInfo.ModelId
-                                // DriverData[].DriverInfo.TeamId
-                                // DriverData[].DriverInfo.LiveryId
-                                // DriverData[].DriverInfo.ManufacturerId
-                                // DriverData[].DriverInfo.UserId
-
-                                w.WriteNumber("SlotId", vehicle.Id);
-                                w.WriteNumber("ClassPerformanceIndex", vehicle.ClassPerformanceIndex);
-
-                                // DriverData[].DriverInfo.EngineType
-                            });
-
-                            // DriverData[].FinishStatus
-                            // DriverData[].Place
-
-                            w.WriteNumber("PlaceClass", vehicle.PositionClass);
-                            w.WriteRoundedNumber("LapDistance", vehicle.CurrentLapDistance.Value.M);
-                            w.WriteCoordinates("Position", vehicle.Location, d => d.M);
-
-                            // DriverData[].TrackSector
-
-                            w.WriteNumber("CompletedLaps", vehicle.CompletedLaps);
-
-                            // DriverData[].CurrentLapValid
-                            // DriverData[].LapTimeCurrentSelf
-                            // DriverData[].SectorTimeCurrentSelf.Sector1
-                            // DriverData[].SectorTimeCurrentSelf.Sector2
-                            // DriverData[].SectorTimeCurrentSelf.Sector3
-                            // DriverData[].SectorTimePreviousSelf.Sector1
-                            // DriverData[].SectorTimePreviousSelf.Sector2
-                            // DriverData[].SectorTimePreviousSelf.Sector3
-
-                            w.WriteSectors("SectorTimeBestSelf", vehicle.BestLapTime?.Sectors.Cumulative, st => st.TotalSeconds);
-                            w.WriteRoundedNumber("TimeDeltaFront", vehicle.GapAhead?.TotalSeconds ?? -1.0);
-                            w.WriteRoundedNumber("TimeDeltaBehind", vehicle.GapBehind?.TotalSeconds ?? -1.0);
-
-                            // DriverData[].PitStopStatus
-                            // DriverData[].InPitlane
-                            // DriverData[].NumPitstops
-                            // DriverData[].Penalties.DriveThrough
-                            // DriverData[].Penalties.StopAndGo
-                            // DriverData[].Penalties.PitStop
-                            // DriverData[].Penalties.TimeDeduction
-                            // DriverData[].Penalties.SlowDown
-                            // DriverData[].CarSpeed
-                            // DriverData[].TireTypeFront
-                            // DriverData[].TireTypeRear
-                            // DriverData[].TireSubtypeFront
-                            // DriverData[].TireSubtypeRear
-                            // DriverData[].BasePenaltyWeight
-                            // DriverData[].AidPenaltyWeight
-                            // DriverData[].DrsState
-                            // DriverData[].PtpState
-                            // DriverData[].PenaltyType
-                            // DriverData[].PenaltyReason
-                        });
-                    }
-                });
+            w.WriteObject("AidSettings", _ =>
+            {
+                w.WriteNumber("Abs", ToInt32(gt.Player?.DrivingAids.Abs));
+                w.WriteNumber("Tc", ToInt32(gt.Player?.DrivingAids.Tc));
+                w.WriteNumber("Esp", ToInt32(gt.Player?.DrivingAids.Esp));
+                w.WriteNumber("Countersteer", ToInt32(gt.Player?.DrivingAids.Countersteer));
+                w.WriteNumber("Cornering", ToInt32(gt.Player?.DrivingAids.Cornering));
             });
-        }
 
-        private static Interval<int> PitWindowBoundaries(IGameTelemetry gt) =>
-            (gt.Session?.Requirements.PitWindow) switch
+            w.WriteObject("Drs", _ =>
             {
-                (LapsDuration start, LapsDuration finish)
-                        when gt.FocusedVehicle?.CompletedLaps.CompareTo(finish.Laps) < 0 =>
-                    new Interval<int>(Convert.ToInt32(start.Laps), Convert.ToInt32(finish.Laps)),
-                (TimeDuration start, TimeDuration finish)
-                        when gt.Session.ElapsedTime < finish.Time =>
-                    new Interval<int>(Convert.ToInt32(start.Time.TotalMinutes), Convert.ToInt32(finish.Time.TotalMinutes)),
-                _ =>
-                    new Interval<int>(-1, -1)
-            };
-
-        private static void ForEachTire(ITire[][]? tires, Action<string, ITire?> action)
-        {
-            action("FrontLeft", tires?.GetValueOrNull(0, 0));
-            action("FrontRight", tires?.GetValueOrNull(0, 1));
-            action("RearLeft", tires?.GetValueOrNull(1, 0));
-            action("RearRight", tires?.GetValueOrNull(1, 1));
-        }
-
-        private static byte[] NullTerminated(string? value) => Encoding.UTF8.GetBytes($"{value ?? ""}\0");
-
-        private static uint ToUInt32(double? value)
-        {
-            try
-            {
-                return Convert.ToUInt32(value);
-            } catch
-            {
-                return 0;
-            }
-        }
-
-        private static int ToInt32(uint? value)
-        {
-            if (value is null || value > int.MaxValue)
-                return -1;
-            return Convert.ToInt32(value);
-        }
-
-        private static int ToInt32(bool? value)
-        {
-            return MatchAsInt32(value, true);
-        }
-
-        private static int MatchAsInt32<T>(T? value, T constant)
-        {
-            return ToInt32(value, v => ToInt32(constant!.Equals(v)));
-        }
-
-        private static int ToInt32(IStartLights? startLights)
-        {
-            return ToInt32(startLights, sl =>
-            {
-                if (sl.Color == LightColor.Green)
-                    return 6;
+                if (gt.Player is null)
+                {
+                    w.WriteNumber("Equipped", -1);
+                    w.WriteNumber("Available", -1);
+                    w.WriteNumber("NumActivationsLeft", -1);
+                    w.WriteNumber("Engaged", -1);
+                }
+                else if (gt.Player.Drs is null)
+                {
+                    w.WriteNumber("Equipped", 0);
+                    w.WriteNumber("Available", 0);
+                    w.WriteNumber("NumActivationsLeft", 0);
+                    w.WriteNumber("Engaged", 0);
+                }
                 else
-                    return Convert.ToInt32(5 * sl.Lit.Value / sl.Lit.Total);
+                {
+                    w.WriteNumber("Equipped", 1);
+                    w.WriteNumber("Available", gt.Player.Drs.Available ? 1 : 0);
+                    w.WriteNumber("NumActivationsLeft", ToInt32(gt.Player.Drs.ActivationsLeft?.Value));
+                    w.WriteNumber("Engaged", gt.Player.Drs.Engaged ? 1 : 0);
+                }
             });
-        }
 
-        private static int ToInt32<T>(T? value, Func<T, int> f)
-        {
-            if (value is null)
-                return -1;
-            return f(value);
-        }
+            // PitLimiter
 
-        private static int ToInt32(bool value)
-        {
-            return value ? 1 : 0;
-        }
-
-        private static int ToInt32(IAid? aid)
-        {
-            if (aid?.Active == true)
-                return 5;
-            return ToInt32(aid?.Level);
-        }
-
-        private static int PitWindowStatusAsInt32(IGameTelemetry gt)
-        {
-            var s = gt.Session;
-            if (s is null)
-                return -1; // Unavailable
-            if (!s.PitLaneOpen)
-                return 0; // Disabled
-
-            var fv = gt.FocusedVehicle;
-            if (fv is null)
-                return -1; // Unavailable
-
-            if (fv.Pit.PitLanePhase == PitLanePhase.Stopped)
-                return 3; // Stopped
-
-            var pitWindow = s.Requirements.PitWindow;
-            if (pitWindow is null)
-                return 2; // Open
-
-            if (fv.Pit.MandatoryStopsDone >= s.Requirements.MandatoryPitStops)
-                return 4; // Completed
-
-            // This should stay open even when in the pits when the time expires.
-            // Not worth implementing it though, as it's both difficult and pointless.
-            var raceInstant = new RaceInstant(s.ElapsedTime, fv.CompletedLaps);
-
-            if (raceInstant.IsWithin(pitWindow))
-                return 2;
-
-            return 1; // Closed
-        }
-
-        private static int InPitLaneAsInt32(IVehicle? vehicle)
-        {
-            if (vehicle is null)
-                return -1;
-            if (vehicle.Pit.PitLanePhase is null)
-                return 0;
-            return 1;
-        }
-
-        private static int PitStateAsInt32(IGameTelemetry gt)
-        {
-            if (gt.FocusedVehicle is null)
-                return -1;
-            switch (gt.FocusedVehicle?.Pit.PitLanePhase)
+            w.WriteObject("PushToPass", _ =>
             {
-                case PitLanePhase.Entered:
-                    return 2;
-                case PitLanePhase.Stopped:
-                    return 3;
-                case PitLanePhase.Exiting:
-                    return 4;
-            }
-            if (gt.Player?.PitStopStatus.HasFlag(PlayerPitStop.Requested) ?? false)
-                return 1;
+                w.WriteNumber("Available", ToInt32(gt.Player?.PushToPass?.Available));
+                w.WriteNumber("Engaged", ToInt32(gt.Player?.PushToPass?.Engaged));
+                w.WriteNumber("AmountLeft", ToInt32(gt.Player?.PushToPass?.ActivationsLeft?.Value));
+                w.WriteRoundedNumber("EngagedTimeLeft", gt.Player?.PushToPass?.EngagedTimeLeft.TotalSeconds ?? -1.0); // not sure
+                w.WriteRoundedNumber("WaitTimeLeft", gt.Player?.PushToPass?.WaitTimeLeft.TotalSeconds ?? -1.0); // not sure
+            });
+
+            // BrakeBias
+
+            w.WriteNumber("DrsNumActivationsTotal", ToInt32(gt.Player?.Drs?.ActivationsLeft?.Total));
+            w.WriteNumber("PtPNumActivationsTotal", ToInt32(gt.Player?.PushToPass?.ActivationsLeft?.Total)); // ********************** is this per lap?!?!?!?!?!?
+
+            // TireType
+            // TireRps.FrontLeft
+            // TireRps.FrontRight
+            // TireRps.RearLeft
+            // TireRps.RearRight
+            // TireSpeed.FrontLeft
+            // TireSpeed.FrontRight
+            // TireSpeed.RearLeft
+            // TireSpeed.RearRight
+
+            w.WriteObject("TireGrip", _ =>
+            {
+                ForEachTire(gt.Player?.Tires, (tireName, tire) =>
+                {
+                    w.WriteRoundedNumber(tireName, tire?.Grip ?? -1.0);
+                });
+            });
+
+            w.WriteObject("TireWear", _ =>
+            {
+                ForEachTire(gt.Player?.Tires, (tireName, tire) =>
+                {
+                    w.WriteRoundedNumber(tireName, tire?.Wear ?? -1.0);
+                });
+            });
+
+            // TireFlatspot.FrontLeft
+            // TireFlatspot.FrontRight
+            // TireFlatspot.RearLeft
+            // TireFlatspot.RearRight
+            // TirePressure.FrontLeft
+            // TirePressure.FrontRight
+            // TirePressure.RearLeft
+            // TirePressure.RearRight
+
+            w.WriteObject("TireDirt", _ =>
+            {
+                ForEachTire(gt.Player?.Tires, (tireName, tire) =>
+                {
+                    w.WriteRoundedNumber(tireName, tire?.Dirt ?? -1.0);
+                });
+            });
+
+            w.WriteObject("TireTemp", _ =>
+            {
+                ForEachTire(gt.Player?.Tires, (tireName, tire) =>
+                {
+                    w.WriteObject(tireName, _ =>
+                    {
+                        var temperatures = tire?.Temperatures;
+                        w.WriteObject("CurrentTemp", _ =>
+                        {
+                            var currentTemperatures = temperatures?.CurrentTemperatures;
+                            w.WriteRoundedNumber("Left", currentTemperatures?.GetValueOrNull(0, 0)?.C ?? -1.0);
+                            w.WriteRoundedNumber("Center", currentTemperatures?.GetValueOrNull(0, 1)?.C ?? -1.0);
+                            w.WriteRoundedNumber("Right", currentTemperatures?.GetValueOrNull(0, 2)?.C ?? -1.0);
+                        });
+                        w.WriteRoundedNumber("OptimalTemp", temperatures?.OptimalTemperature.C ?? -1.0);
+                        w.WriteRoundedNumber("ColdTemp", temperatures?.ColdTemperature.C ?? -1.0);
+                        w.WriteRoundedNumber("HotTemp", temperatures?.HotTemperature.C ?? -1.0);
+                    });
+                });
+            });
+
+            // TireTypeFront
+            // TireTypeRear
+            // TireSubtypeFront
+            // TireSubtypeRear
+
+            w.WriteObject("BrakeTemp", _ =>
+            {
+                ForEachTire(gt.Player?.Tires, (tireName, tire) =>
+                {
+                    w.WriteObject(tireName, _ =>
+                    {
+                        w.WriteRoundedNumber("CurrentTemp", tire?.BrakeTemperatures.CurrentTemperature.C ?? -1.0);
+                        w.WriteRoundedNumber("OptimalTemp", tire?.BrakeTemperatures.OptimalTemperature.C ?? - 1.0);
+                        w.WriteRoundedNumber("ColdTemp", tire?.BrakeTemperatures.ColdTemperature.C ?? - 1.0);
+                        w.WriteRoundedNumber("HotTemp", tire?.BrakeTemperatures.HotTemperature.C ?? - 1.0);
+                    });
+                });
+            });
+
+            // BrakePressure.FrontLeft
+            // BrakePressure.FrontRight
+            // BrakePressure.RearLeft
+            // BrakePressure.RearRight
+            // TractionControlSetting
+            // EngineMapSetting
+            // EngineBrakeSetting
+            // TireLoad.FrontLeft
+            // TireLoad.FrontRight
+            // TireLoad.RearLeft
+            // TireLoad.RearRight
+
+            w.WriteObject("CarDamage", _ =>
+            {
+                w.WriteRoundedNumber("Engine", gt.Player?.VehicleDamage.EnginePercent ?? -1.0);
+                w.WriteRoundedNumber("Transmission", gt.Player?.VehicleDamage.TransmissionPercent ?? -1.0);
+                w.WriteRoundedNumber("Aerodynamics", gt.Player?.VehicleDamage.AerodynamicsPercent ?? -1.0);
+                w.WriteRoundedNumber("Suspension", gt.Player?.VehicleDamage.SuspensionPercent ?? -1.0);
+            });
+
+            // NumCars
+
+            // Note: Sometimes there's a lot of "null" vehicles after NumCars, but we won't render them.
+            w.WriteArray("DriverData", _ =>
+            {
+                foreach (var vehicle in gt.Vehicles)
+                {
+                    w.WriteObject(_ =>
+                    {
+                        w.WriteObject("DriverInfo", _ =>
+                        {
+                            w.WriteBase64String("Name", NullTerminated(vehicle.CurrentDriver.Name));
+
+                            // DriverData[].DriverInfo.CarNumber
+                            // DriverData[].DriverInfo.ClassId
+                            // DriverData[].DriverInfo.ModelId
+                            // DriverData[].DriverInfo.TeamId
+                            // DriverData[].DriverInfo.LiveryId
+                            // DriverData[].DriverInfo.ManufacturerId
+                            // DriverData[].DriverInfo.UserId
+
+                            w.WriteNumber("SlotId", vehicle.Id);
+                            w.WriteNumber("ClassPerformanceIndex", vehicle.ClassPerformanceIndex);
+
+                            // DriverData[].DriverInfo.EngineType
+                        });
+
+                        // DriverData[].FinishStatus
+                        // DriverData[].Place
+
+                        w.WriteNumber("PlaceClass", vehicle.PositionClass);
+                        w.WriteRoundedNumber("LapDistance", vehicle.CurrentLapDistance.Value.M);
+                        w.WriteCoordinates("Position", vehicle.Location, d => d.M);
+
+                        // DriverData[].TrackSector
+
+                        w.WriteNumber("CompletedLaps", vehicle.CompletedLaps);
+
+                        // DriverData[].CurrentLapValid
+                        // DriverData[].LapTimeCurrentSelf
+                        // DriverData[].SectorTimeCurrentSelf.Sector1
+                        // DriverData[].SectorTimeCurrentSelf.Sector2
+                        // DriverData[].SectorTimeCurrentSelf.Sector3
+                        // DriverData[].SectorTimePreviousSelf.Sector1
+                        // DriverData[].SectorTimePreviousSelf.Sector2
+                        // DriverData[].SectorTimePreviousSelf.Sector3
+
+                        w.WriteSectors("SectorTimeBestSelf", vehicle.BestLapTime?.Sectors.Cumulative, st => st.TotalSeconds);
+                        w.WriteRoundedNumber("TimeDeltaFront", vehicle.GapAhead?.TotalSeconds ?? -1.0);
+                        w.WriteRoundedNumber("TimeDeltaBehind", vehicle.GapBehind?.TotalSeconds ?? -1.0);
+
+                        // DriverData[].PitStopStatus
+                        // DriverData[].InPitlane
+                        // DriverData[].NumPitstops
+                        // DriverData[].Penalties.DriveThrough
+                        // DriverData[].Penalties.StopAndGo
+                        // DriverData[].Penalties.PitStop
+                        // DriverData[].Penalties.TimeDeduction
+                        // DriverData[].Penalties.SlowDown
+                        // DriverData[].CarSpeed
+                        // DriverData[].TireTypeFront
+                        // DriverData[].TireTypeRear
+                        // DriverData[].TireSubtypeFront
+                        // DriverData[].TireSubtypeRear
+                        // DriverData[].BasePenaltyWeight
+                        // DriverData[].AidPenaltyWeight
+                        // DriverData[].DrsState
+                        // DriverData[].PtpState
+                        // DriverData[].PenaltyType
+                        // DriverData[].PenaltyReason
+                    });
+                }
+            });
+        });
+    }
+
+    private static Interval<int> PitWindowBoundaries(IGameTelemetry gt) =>
+        (gt.Session?.Requirements.PitWindow) switch
+        {
+            (LapsDuration start, LapsDuration finish)
+                when gt.FocusedVehicle?.CompletedLaps.CompareTo(finish.Laps) < 0 =>
+                new Interval<int>(Convert.ToInt32(start.Laps), Convert.ToInt32(finish.Laps)),
+            (TimeDuration start, TimeDuration finish)
+                when gt.Session.ElapsedTime < finish.Time =>
+                new Interval<int>(Convert.ToInt32(start.Time.TotalMinutes), Convert.ToInt32(finish.Time.TotalMinutes)),
+            _ =>
+                new Interval<int>(-1, -1)
+        };
+
+    private static void ForEachTire(ITire[][]? tires, Action<string, ITire?> action)
+    {
+        action("FrontLeft", tires?.GetValueOrNull(0, 0));
+        action("FrontRight", tires?.GetValueOrNull(0, 1));
+        action("RearLeft", tires?.GetValueOrNull(1, 0));
+        action("RearRight", tires?.GetValueOrNull(1, 1));
+    }
+
+    private static byte[] NullTerminated(string? value) => Encoding.UTF8.GetBytes($"{value ?? ""}\0");
+
+    private static uint ToUInt32(double? value)
+    {
+        try
+        {
+            return Convert.ToUInt32(value);
+        } catch
+        {
             return 0;
         }
-
-        private static int PitActionAsInt32(IPlayer? player)
-        {
-            if (player is null)
-                return -1;
-            var pitAction = 0;
-            foreach (var (playerPitStopFlag, pitActionFlag) in PitActionMapping)
-                if (player.PitStopStatus.HasFlag(playerPitStopFlag)) pitAction += pitActionFlag;
-            return pitAction;
-        }
-
-        private static readonly (PlayerPitStop, int)[] PitActionMapping = {
-                (PlayerPitStop.Preparing,        1 << 0),
-                (PlayerPitStop.ServingPenalty,   1 << 1),
-                (PlayerPitStop.DriverChange,     1 << 2),
-                (PlayerPitStop.Refuelling,       1 << 3),
-                (PlayerPitStop.ChangeFrontTires, 1 << 4),
-                (PlayerPitStop.ChangeRearTires,  1 << 5),
-                (PlayerPitStop.RepairBody,       1 << 6),
-                (PlayerPitStop.RepairFrontWing,  1 << 7),
-                (PlayerPitStop.RepairRearWing,   1 << 8),
-                (PlayerPitStop.RepairSuspension, 1 << 9)
-            };
-
-
-        private static int BlackWhiteFlagAsInt32(IVehicleFlags.IBlackWhite? blackWhiteFlag, uint? blueFlagWarnings, bool raceStarted)
-        {
-            if (!raceStarted)
-                return -1;
-            return (blackWhiteFlag?.Reason, blueFlagWarnings) switch
-            {
-                (IVehicleFlags.BlackWhiteReason.IgnoredBlueFlags, 1) => 1,
-                (IVehicleFlags.BlackWhiteReason.IgnoredBlueFlags, 2) => 2,
-                (IVehicleFlags.BlackWhiteReason.WrongWay, _) => 3,
-                (IVehicleFlags.BlackWhiteReason.Cutting, _) => 4,
-                _ => 0
-            };
-        }
-
-        private static int FlagAsInt32(IVehicleFlags.IFlag? flag) =>
-            ToInt32(flag is not null);
-
-        private static int ConditionalFlagAsInt32(IVehicleFlags.IFlag? flag, bool raceStarted) =>
-            Conditional(ToInt32(flag is not null), raceStarted);
-
-        private static int Conditional(int value, bool raceStarted) =>
-            raceStarted ? value : -1;
     }
 
-    internal static class R3EDashExtensions
+    private static int ToInt32(uint? value)
     {
-        private static readonly int DecimalDigits = 3;
-
-        public static void WriteRoundedNumber(this Utf8JsonWriter writer, String propertyName, double value)
-        {
-            writer.WriteNumber(propertyName, value, DecimalDigits);
-        }
-
-        public static void WriteSectors<T>(this Utf8JsonWriter writer, String propertyName, T[]? v, Func<T, double> f)
-        {
-            writer.WriteObject(propertyName, _ =>
-            {
-                for (int i = 0; i < 3; i++)
-                {
-                    writer.WriteRoundedNumber("Sector" + (i + 1), v?.Length > i ? f(v[i]) : -1.0);
-                }
-            });
-        }
-
-        public static void WriteCoordinates<T>(this Utf8JsonWriter writer, String propertyName, Vector3<T>? v, Func<T, double> f)
-        {
-            writer.WriteObject(propertyName, _ =>
-            {
-                writer.WriteRoundedNumber("X", v is not null ? f(v.X) : 0.0);
-                writer.WriteRoundedNumber("Y", v is not null ? f(v.Y) : 0.0);
-                writer.WriteRoundedNumber("Z", v is not null ? f(v.Z) : 0.0);
-            });
-        }
-
-        public static void WriteOrientationPyr(this Utf8JsonWriter writer, string propertyName, Orientation? v, Func<IAngle, double> f)
-        {
-            writer.WriteObject(propertyName, _ =>
-            {
-                writer.WriteRoundedNumber("Pitch", v is not null ? f(v.Pitch) : 0.0);
-                writer.WriteRoundedNumber("Yaw", v is not null ? f(v.Yaw) : 0.0);
-                writer.WriteRoundedNumber("Roll", v is not null ? f(v.Roll) : 0.0);
-            });
-        }
-        
-        public static T? GetValueOrNull<T>(this T[][] array, int i, int j) =>
-            (i < array.Length && j < array[i].Length) ? array[i][j] : default(T);
+        if (value is null || value > int.MaxValue)
+            return -1;
+        return Convert.ToInt32(value);
     }
+
+    private static int ToInt32(bool? value)
+    {
+        return MatchAsInt32(value, true);
+    }
+
+    private static int MatchAsInt32<T>(T? value, T constant)
+    {
+        return ToInt32(value, v => ToInt32(constant!.Equals(v)));
+    }
+
+    private static int ToInt32(IStartLights? startLights)
+    {
+        return ToInt32(startLights, sl =>
+        {
+            if (sl.Color == LightColor.Green)
+                return 6;
+            else
+                return Convert.ToInt32(5 * sl.Lit.Value / sl.Lit.Total);
+        });
+    }
+
+    private static int ToInt32<T>(T? value, Func<T, int> f)
+    {
+        if (value is null)
+            return -1;
+        return f(value);
+    }
+
+    private static int ToInt32(bool value)
+    {
+        return value ? 1 : 0;
+    }
+
+    private static int ToInt32(IAid? aid)
+    {
+        if (aid?.Active == true)
+            return 5;
+        return ToInt32(aid?.Level);
+    }
+
+    private static int PitWindowStatusAsInt32(IGameTelemetry gt)
+    {
+        var s = gt.Session;
+        if (s is null)
+            return -1; // Unavailable
+        if (!s.PitLaneOpen)
+            return 0; // Disabled
+
+        var fv = gt.FocusedVehicle;
+        if (fv is null)
+            return -1; // Unavailable
+
+        if (fv.Pit.PitLanePhase == PitLanePhase.Stopped)
+            return 3; // Stopped
+
+        var pitWindow = s.Requirements.PitWindow;
+        if (pitWindow is null)
+            return 2; // Open
+
+        if (fv.Pit.MandatoryStopsDone >= s.Requirements.MandatoryPitStops)
+            return 4; // Completed
+
+        // This should stay open even when in the pits when the time expires.
+        // Not worth implementing it though, as it's both difficult and pointless.
+        var raceInstant = new RaceInstant(s.ElapsedTime, fv.CompletedLaps);
+
+        if (raceInstant.IsWithin(pitWindow))
+            return 2;
+
+        return 1; // Closed
+    }
+
+    private static int InPitLaneAsInt32(IVehicle? vehicle)
+    {
+        if (vehicle is null)
+            return -1;
+        if (vehicle.Pit.PitLanePhase is null)
+            return 0;
+        return 1;
+    }
+
+    private static int PitStateAsInt32(IGameTelemetry gt)
+    {
+        if (gt.FocusedVehicle is null)
+            return -1;
+        switch (gt.FocusedVehicle?.Pit.PitLanePhase)
+        {
+            case PitLanePhase.Entered:
+                return 2;
+            case PitLanePhase.Stopped:
+                return 3;
+            case PitLanePhase.Exiting:
+                return 4;
+        }
+        if (gt.Player?.PitStopStatus.HasFlag(PlayerPitStop.Requested) ?? false)
+            return 1;
+        return 0;
+    }
+
+    private static int PitActionAsInt32(IPlayer? player)
+    {
+        if (player is null)
+            return -1;
+        var pitAction = 0;
+        foreach (var (playerPitStopFlag, pitActionFlag) in PitActionMapping)
+            if (player.PitStopStatus.HasFlag(playerPitStopFlag)) pitAction += pitActionFlag;
+        return pitAction;
+    }
+
+    private static readonly (PlayerPitStop, int)[] PitActionMapping = {
+        (PlayerPitStop.Preparing,        1 << 0),
+        (PlayerPitStop.ServingPenalty,   1 << 1),
+        (PlayerPitStop.DriverChange,     1 << 2),
+        (PlayerPitStop.Refuelling,       1 << 3),
+        (PlayerPitStop.ChangeFrontTires, 1 << 4),
+        (PlayerPitStop.ChangeRearTires,  1 << 5),
+        (PlayerPitStop.RepairBody,       1 << 6),
+        (PlayerPitStop.RepairFrontWing,  1 << 7),
+        (PlayerPitStop.RepairRearWing,   1 << 8),
+        (PlayerPitStop.RepairSuspension, 1 << 9)
+    };
+
+
+    private static int BlackWhiteFlagAsInt32(IVehicleFlags.IBlackWhite? blackWhiteFlag, uint? blueFlagWarnings, bool raceStarted)
+    {
+        if (!raceStarted)
+            return -1;
+        return (blackWhiteFlag?.Reason, blueFlagWarnings) switch
+        {
+            (IVehicleFlags.BlackWhiteReason.IgnoredBlueFlags, 1) => 1,
+            (IVehicleFlags.BlackWhiteReason.IgnoredBlueFlags, 2) => 2,
+            (IVehicleFlags.BlackWhiteReason.WrongWay, _) => 3,
+            (IVehicleFlags.BlackWhiteReason.Cutting, _) => 4,
+            _ => 0
+        };
+    }
+
+    private static int FlagAsInt32(IVehicleFlags.IFlag? flag) =>
+        ToInt32(flag is not null);
+
+    private static int ConditionalFlagAsInt32(IVehicleFlags.IFlag? flag, bool raceStarted) =>
+        Conditional(ToInt32(flag is not null), raceStarted);
+
+    private static int Conditional(int value, bool raceStarted) =>
+        raceStarted ? value : -1;
+}
+
+internal static class R3EDashExtensions
+{
+    private static readonly int DecimalDigits = 3;
+
+    public static void WriteRoundedNumber(this Utf8JsonWriter writer, String propertyName, double value)
+    {
+        writer.WriteNumber(propertyName, value, DecimalDigits);
+    }
+
+    public static void WriteSectors<T>(this Utf8JsonWriter writer, String propertyName, T[]? v, Func<T, double> f)
+    {
+        writer.WriteObject(propertyName, _ =>
+        {
+            for (int i = 0; i < 3; i++)
+            {
+                writer.WriteRoundedNumber("Sector" + (i + 1), v?.Length > i ? f(v[i]) : -1.0);
+            }
+        });
+    }
+
+    public static void WriteCoordinates<T>(this Utf8JsonWriter writer, String propertyName, Vector3<T>? v, Func<T, double> f)
+    {
+        writer.WriteObject(propertyName, _ =>
+        {
+            writer.WriteRoundedNumber("X", v is not null ? f(v.X) : 0.0);
+            writer.WriteRoundedNumber("Y", v is not null ? f(v.Y) : 0.0);
+            writer.WriteRoundedNumber("Z", v is not null ? f(v.Z) : 0.0);
+        });
+    }
+
+    public static void WriteOrientationPyr(this Utf8JsonWriter writer, string propertyName, Orientation? v, Func<IAngle, double> f)
+    {
+        writer.WriteObject(propertyName, _ =>
+        {
+            writer.WriteRoundedNumber("Pitch", v is not null ? f(v.Pitch) : 0.0);
+            writer.WriteRoundedNumber("Yaw", v is not null ? f(v.Yaw) : 0.0);
+            writer.WriteRoundedNumber("Roll", v is not null ? f(v.Roll) : 0.0);
+        });
+    }
+        
+    public static T? GetValueOrNull<T>(this T[][] array, int i, int j) =>
+        (i < array.Length && j < array[i].Length) ? array[i][j] : default(T);
 }

--- a/src/Plugins/HUD/Pipeline/WebSocketNodeBase.cs
+++ b/src/Plugins/HUD/Pipeline/WebSocketNodeBase.cs
@@ -3,38 +3,37 @@ using System;
 using System.Collections.Generic;
 using System.Reactive;
 
-namespace RaceDirector.Plugin.HUD.Pipeline
+namespace RaceDirector.Plugin.HUD.Pipeline;
+
+/// <summary>
+/// Starts and stops WebSocket servers based on trigger input.
+/// Broadcasts to all WebSocket clients on data input.
+/// </summary>
+/// <typeparam name="TTrigger">Trigger type</typeparam>
+/// <typeparam name="TData">Data type</typeparam>
+public abstract class WebSocketNodeBase<TTrigger, TData>
 {
-    /// <summary>
-    /// Starts and stops WebSocket servers based on trigger input.
-    /// Broadcasts to all WebSocket clients on data input.
-    /// </summary>
-    /// <typeparam name="TTrigger">Trigger type</typeparam>
-    /// <typeparam name="TData">Data type</typeparam>
-    public abstract class WebSocketNodeBase<TTrigger, TData>
+    protected readonly IObserver<TTrigger> TriggerObserver;
+    protected readonly IObserver<TData> DataObserver;
+
+    protected WebSocketNodeBase(IEnumerable<IWsServer<TData>> servers)
     {
-        protected readonly IObserver<TTrigger> TriggerObserver;
-        protected readonly IObserver<TData> DataObserver;
-
-        protected WebSocketNodeBase(IEnumerable<IWsServer<TData>> servers)
+        TriggerObserver = Observer.Create<TTrigger>(trigger => {
+            if (ServerShouldRun(trigger))
+                foreach (var s in servers) s.Start();
+            else
+                foreach (var s in servers) s.Stop();
+        });
+        DataObserver = Observer.Create<TData>(data =>
         {
-            TriggerObserver = Observer.Create<TTrigger>(trigger => {
-                if (ServerShouldRun(trigger))
-                    foreach (var s in servers) s.Start();
-                else
-                    foreach (var s in servers) s.Stop();
-            });
-            DataObserver = Observer.Create<TData>(data =>
-            {
-                foreach (var s in servers) s.Multicast(data);
-            });
-        }
-
-        /// <summary>
-        /// Returns if the trigger data should start ot stop the servers.
-        /// </summary>
-        /// <param name="trigger"></param>
-        /// <returns></returns>
-        protected abstract bool ServerShouldRun(TTrigger trigger);
+            foreach (var s in servers) s.Multicast(data);
+        });
     }
+
+    /// <summary>
+    /// Returns if the trigger data should start ot stop the servers.
+    /// </summary>
+    /// <param name="trigger"></param>
+    /// <returns></returns>
+    protected abstract bool ServerShouldRun(TTrigger trigger);
 }

--- a/src/Plugins/HUD/Pipeline/WebSocketTelemetryNode.cs
+++ b/src/Plugins/HUD/Pipeline/WebSocketTelemetryNode.cs
@@ -5,21 +5,20 @@ using RaceDirector.Plugin.HUD.Server;
 using System.Collections.Generic;
 using System;
 
-namespace RaceDirector.Plugin.HUD.Pipeline
+namespace RaceDirector.Plugin.HUD.Pipeline;
+
+/// <summary>
+/// Exposes live telemetry as a web socket server.
+/// </summary>
+public class WebSocketTelemetryNode : WebSocketNodeBase<IRunningGame, IGameTelemetry>, INode
 {
-    /// <summary>
-    /// Exposes live telemetry as a web socket server.
-    /// </summary>
-    public class WebSocketTelemetryNode : WebSocketNodeBase<IRunningGame, IGameTelemetry>, INode
-    {
-        public IObserver<IRunningGame> RunningGameObserver => TriggerObserver;
+    public IObserver<IRunningGame> RunningGameObserver => TriggerObserver;
 
-        public IObserver<IGameTelemetry> GameTelemetryObserver => DataObserver;
+    public IObserver<IGameTelemetry> GameTelemetryObserver => DataObserver;
 
-        public WebSocketTelemetryNode(IEnumerable<IWsServer<IGameTelemetry>> servers) : base(servers) { }
+    public WebSocketTelemetryNode(IEnumerable<IWsServer<IGameTelemetry>> servers) : base(servers) { }
 
-        protected override bool ServerShouldRun(IRunningGame runningGame) {
-            return runningGame.IsRunning();
-        }
+    protected override bool ServerShouldRun(IRunningGame runningGame) {
+        return runningGame.IsRunning();
     }
 }

--- a/src/Plugins/HUD/Plugin.cs
+++ b/src/Plugins/HUD/Plugin.cs
@@ -2,21 +2,20 @@
 using RaceDirector.DependencyInjection;
 using RaceDirector.Plugin.HUD.Pipeline;
 
-namespace RaceDirector.Plugin.HUD
-{
-    public class Plugin : PluginBase<Plugin.Configuration>
-    {
-        public class Configuration
-        {
-            public DashboardServer.Config DashboardServer { get; set; } = null!;
-        }
+namespace RaceDirector.Plugin.HUD;
 
-        protected override void Init(Configuration configuration, IServiceCollection services)
-        {
-            services
-                .AddSingletonWithInterfaces(_ => configuration.DashboardServer)
-                .AddTransientWithInterfaces<DashboardServer>()
-                .AddTransientWithInterfaces<WebSocketTelemetryNode>();
-        }
+public class Plugin : PluginBase<Plugin.Configuration>
+{
+    public class Configuration
+    {
+        public DashboardServer.Config DashboardServer { get; set; } = null!;
+    }
+
+    protected override void Init(Configuration configuration, IServiceCollection services)
+    {
+        services
+            .AddSingletonWithInterfaces(_ => configuration.DashboardServer)
+            .AddTransientWithInterfaces<DashboardServer>()
+            .AddTransientWithInterfaces<WebSocketTelemetryNode>();
     }
 }

--- a/src/Plugins/HUD/Server/Endpoint.cs
+++ b/src/Plugins/HUD/Server/Endpoint.cs
@@ -1,30 +1,29 @@
 ﻿using NetCoreServer;
 using System;
 
-namespace RaceDirector.Plugin.HUD.Server
+namespace RaceDirector.Plugin.HUD.Server;
+
+public class Endpoint<T> : IEndpoint<T>
 {
-    public class Endpoint<T> : IEndpoint<T>
+    private readonly Func<HttpRequest, bool> _matches;
+    private readonly Func<T, byte[]> _transform;
+
+    public Endpoint(Func<HttpRequest, bool> matches, Func<T, byte[]> transform)
     {
-        private readonly Func<HttpRequest, bool> _matches;
-        private readonly Func<T, byte[]> _transform;
-
-        public Endpoint(Func<HttpRequest, bool> matches, Func<T, byte[]> transform)
-        {
-            _matches = matches;
-            _transform = transform;
-        }
-
-        public bool Matches(HttpRequest request) => _matches(request);
-
-        public byte[] Transform(T t) => _transform(t);
+        _matches = matches;
+        _transform = transform;
     }
 
-    public static class Endpoint
+    public bool Matches(HttpRequest request) => _matches(request);
+
+    public byte[] Transform(T t) => _transform(t);
+}
+
+public static class Endpoint
+{
+    public static Func<HttpRequest, bool> PathMatcher(string path) => request =>
     {
-        public static Func<HttpRequest, bool> PathMatcher(string path) => request =>
-        {
-            var requestPath = request.Url.Split('?', 1)[0];
-            return path == requestPath;
-        };
-    }
+        var requestPath = request.Url.Split('?', 1)[0];
+        return path == requestPath;
+    };
 }

--- a/src/Plugins/HUD/Server/IEndpoint.cs
+++ b/src/Plugins/HUD/Server/IEndpoint.cs
@@ -1,11 +1,10 @@
 ﻿using NetCoreServer;
 
-namespace RaceDirector.Plugin.HUD.Server
-{
-    public interface IEndpoint<T>
-    {
-        bool Matches(HttpRequest request);
+namespace RaceDirector.Plugin.HUD.Server;
 
-        byte[] Transform(T t);
-    }
+public interface IEndpoint<T>
+{
+    bool Matches(HttpRequest request);
+
+    byte[] Transform(T t);
 }

--- a/src/Plugins/HUD/Server/ITcpServer.cs
+++ b/src/Plugins/HUD/Server/ITcpServer.cs
@@ -1,10 +1,9 @@
 ﻿using System;
 
-namespace RaceDirector.Plugin.HUD.Server
+namespace RaceDirector.Plugin.HUD.Server;
+
+public interface ITcpServer : IDisposable
 {
-    public interface ITcpServer : IDisposable
-    {
-        bool Start();
-        bool Stop();
-    }
+    bool Start();
+    bool Stop();
 }

--- a/src/Plugins/HUD/Server/IWsServer.cs
+++ b/src/Plugins/HUD/Server/IWsServer.cs
@@ -5,10 +5,9 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace RaceDirector.Plugin.HUD.Server
+namespace RaceDirector.Plugin.HUD.Server;
+
+public interface IWsServer<T> : ITcpServer
 {
-    public interface IWsServer<T> : ITcpServer
-    {
-        bool Multicast(T t);
-    }
+    bool Multicast(T t);
 }

--- a/src/Plugins/HUD/Server/MultiEndpointWsServer.cs
+++ b/src/Plugins/HUD/Server/MultiEndpointWsServer.cs
@@ -5,89 +5,88 @@ using System.Linq;
 using System.Net;
 using Microsoft.Extensions.Logging;
 
-namespace RaceDirector.Plugin.HUD.Server
+namespace RaceDirector.Plugin.HUD.Server;
+
+/// <summary>
+/// WebSocket server that serialises messages differently based on the endpoint that was requested.
+/// </summary>
+/// <typeparam name="T">Type of message that can be broadcasted.</typeparam>
+/// <remarks>NetCoreServer is poorly designed for extensibility. This class could be a lot simpler.</remarks>
+public class MultiEndpointWsServer<T> : WsServer, IWsServer<T>
 {
-    /// <summary>
-    /// WebSocket server that serialises messages differently based on the endpoint that was requested.
-    /// </summary>
-    /// <typeparam name="T">Type of message that can be broadcasted.</typeparam>
-    /// <remarks>NetCoreServer is poorly designed for extensibility. This class could be a lot simpler.</remarks>
-    public class MultiEndpointWsServer<T> : WsServer, IWsServer<T>
+    private readonly List<IEndpoint<T>> _endpoints;
+    protected readonly ILogger Logger;
+
+    public MultiEndpointWsServer(IPAddress address, int port, IEnumerable<IEndpoint<T>> endpoints, ILogger logger)
+        : base(address, port)
     {
-        private readonly List<IEndpoint<T>> _endpoints;
-        protected readonly ILogger Logger;
+        _endpoints = endpoints.ToList();
+        Logger = logger;
+    }
 
-        public MultiEndpointWsServer(IPAddress address, int port, IEnumerable<IEndpoint<T>> endpoints, ILogger logger)
-            : base(address, port)
-        {
-            _endpoints = endpoints.ToList();
-            Logger = logger;
-        }
-
-        protected override TcpSession CreateSession()
-        {
-            return new MultiEndpointWsSession(this);
-        }
+    protected override TcpSession CreateSession()
+    {
+        return new MultiEndpointWsSession(this);
+    }
         
-        /// <summary>
-        /// Multicasts data to all clients connected. Serialisation depends on the endpoint that
-        /// clients are connected to.
-        /// </summary>
-        /// <param name="t">Message</param>
-        public bool Multicast(T t)
+    /// <summary>
+    /// Multicasts data to all clients connected. Serialisation depends on the endpoint that
+    /// clients are connected to.
+    /// </summary>
+    /// <param name="t">Message</param>
+    public bool Multicast(T t)
+    {
+        if (!IsStarted)
         {
-            if (!IsStarted)
-            {
-                Logger.LogTrace("Server stopped; skipping message {T}", t);
-                return false;
-            }
-
-            Logger.LogTrace("Sending message {T}", t);
-            foreach (var session in Sessions.Values)
-            {
-                if (session is MultiEndpointWsSession mewsSession)
-                {
-                    mewsSession.SendAsync(t);
-                }
-            }
-
-            return true;
+            Logger.LogTrace("Server stopped; skipping message {T}", t);
+            return false;
         }
 
-        private class MultiEndpointWsSession : WsSession
+        Logger.LogTrace("Sending message {T}", t);
+        foreach (var session in Sessions.Values)
         {
-            private readonly MultiEndpointWsServer<T> _server;
-            private IEndpoint<T>? _matchedEndpoint;
-            private bool _wsHandshaked;
-
-            public MultiEndpointWsSession(MultiEndpointWsServer<T> server) : base(server)
+            if (session is MultiEndpointWsSession mewsSession)
             {
-                _server = server;
-                _wsHandshaked = false;
+                mewsSession.SendAsync(t);
             }
+        }
 
-            public override bool OnWsConnecting(HttpRequest request, HttpResponse response) {
-                _matchedEndpoint = _server._endpoints.Find(e => e.Matches(request));
-                return _matchedEndpoint != null;
-            }
+        return true;
+    }
 
-            public override void OnWsConnected(HttpRequest request) {
-                _server.Logger.LogDebug("Client connected");
-                _wsHandshaked = true;
-            }
+    private class MultiEndpointWsSession : WsSession
+    {
+        private readonly MultiEndpointWsServer<T> _server;
+        private IEndpoint<T>? _matchedEndpoint;
+        private bool _wsHandshaked;
 
-            public bool SendAsync(T t)
-            {
-                if (_wsHandshaked && _matchedEndpoint != null)
-                    return SendTextAsync(_matchedEndpoint.Transform(t));
-                else
-                    return false;
-            }
+        public MultiEndpointWsSession(MultiEndpointWsServer<T> server) : base(server)
+        {
+            _server = server;
+            _wsHandshaked = false;
+        }
 
-            private bool SendTextAsync(byte[] buffer)
-            {
-                return SendTextAsync(buffer, 0L, buffer.LongLength);
-            }
+        public override bool OnWsConnecting(HttpRequest request, HttpResponse response) {
+            _matchedEndpoint = _server._endpoints.Find(e => e.Matches(request));
+            return _matchedEndpoint != null;
+        }
+
+        public override void OnWsConnected(HttpRequest request) {
+            _server.Logger.LogDebug("Client connected");
+            _wsHandshaked = true;
+        }
+
+        public bool SendAsync(T t)
+        {
+            if (_wsHandshaked && _matchedEndpoint != null)
+                return SendTextAsync(_matchedEndpoint.Transform(t));
+            else
+                return false;
+        }
+
+        private bool SendTextAsync(byte[] buffer)
+        {
+            return SendTextAsync(buffer, 0L, buffer.LongLength);
         }
     }
 }

--- a/src/Plugins/HUD/Utils/JsonWriterExtensions.cs
+++ b/src/Plugins/HUD/Utils/JsonWriterExtensions.cs
@@ -1,34 +1,33 @@
 ﻿using System;
 using System.Text.Json;
 
-namespace RaceDirector.Plugin.HUD.Utils
+namespace RaceDirector.Plugin.HUD.Utils;
+
+public static class JsonWriterExtensions
 {
-    public static class JsonWriterExtensions
+    public static void WriteObject(this Utf8JsonWriter writer, String propertyName, Action<Utf8JsonWriter> f)
     {
-        public static void WriteObject(this Utf8JsonWriter writer, String propertyName, Action<Utf8JsonWriter> f)
-        {
-            writer.WritePropertyName(propertyName);
-            writer.WriteObject(f);
-        }
+        writer.WritePropertyName(propertyName);
+        writer.WriteObject(f);
+    }
 
-        public static void WriteObject(this Utf8JsonWriter writer, Action<Utf8JsonWriter> f)
-        {
-            writer.WriteStartObject();
-            f(writer);
-            writer.WriteEndObject();
-        }
+    public static void WriteObject(this Utf8JsonWriter writer, Action<Utf8JsonWriter> f)
+    {
+        writer.WriteStartObject();
+        f(writer);
+        writer.WriteEndObject();
+    }
 
-        public static void WriteArray(this Utf8JsonWriter writer, String propertyName, Action<Utf8JsonWriter> f)
-        {
-            writer.WriteStartArray(propertyName);
-            f(writer);
-            writer.WriteEndArray();
-        }
+    public static void WriteArray(this Utf8JsonWriter writer, String propertyName, Action<Utf8JsonWriter> f)
+    {
+        writer.WriteStartArray(propertyName);
+        f(writer);
+        writer.WriteEndArray();
+    }
 
-        public static void WriteNumber(this Utf8JsonWriter writer, String propertyName, double value, int decimals)
-        {
-            var roundedValue = Decimal.Round(new Decimal(value), decimals);
-            writer.WriteNumber(propertyName, roundedValue);
-        }
+    public static void WriteNumber(this Utf8JsonWriter writer, String propertyName, double value, int decimals)
+    {
+        var roundedValue = Decimal.Round(new Decimal(value), decimals);
+        writer.WriteNumber(propertyName, roundedValue);
     }
 }

--- a/src/RaceDirector.Interface/Pipeline/GameMonitor/IGameProcessInfo.cs
+++ b/src/RaceDirector.Interface/Pipeline/GameMonitor/IGameProcessInfo.cs
@@ -1,9 +1,8 @@
 ﻿using RaceDirector.Pipeline.Games;
 
-namespace RaceDirector.Pipeline.GameMonitor
+namespace RaceDirector.Pipeline.GameMonitor;
+
+public interface IGameProcessInfo : IGameInfo
 {
-    public interface IGameProcessInfo : IGameInfo
-    {
-        string[] GameProcessNames { get; }
-    }
+    string[] GameProcessNames { get; }
 }

--- a/src/RaceDirector.Interface/Pipeline/GameMonitor/RunningGame.cs
+++ b/src/RaceDirector.Interface/Pipeline/GameMonitor/RunningGame.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 
-namespace RaceDirector.Pipeline.GameMonitor
-{
-    // TODO this is in the interface to make testing easier, but it might be abused
-    public record RunningGame(string? Name) : V0.IRunningGame;
-}
+namespace RaceDirector.Pipeline.GameMonitor;
+
+// TODO this is in the interface to make testing easier, but it might be abused
+public record RunningGame(string? Name) : V0.IRunningGame;

--- a/src/RaceDirector.Interface/Pipeline/Games/IGame.cs
+++ b/src/RaceDirector.Interface/Pipeline/Games/IGame.cs
@@ -1,9 +1,8 @@
 ﻿using RaceDirector.Pipeline.GameMonitor;
 using RaceDirector.Pipeline.Telemetry;
 
-namespace RaceDirector.Pipeline.Games
+namespace RaceDirector.Pipeline.Games;
+
+public interface IGame : ITelemetryObservableFactory, IGameProcessInfo
 {
-    public interface IGame : ITelemetryObservableFactory, IGameProcessInfo
-    {
-    }
 }

--- a/src/RaceDirector.Interface/Pipeline/Games/IGameInfo.cs
+++ b/src/RaceDirector.Interface/Pipeline/Games/IGameInfo.cs
@@ -1,7 +1,6 @@
-﻿namespace RaceDirector.Pipeline.Games
+﻿namespace RaceDirector.Pipeline.Games;
+
+public interface IGameInfo
 {
-    public interface IGameInfo
-    {
-        string GameName { get; }
-    }
+    string GameName { get; }
 }

--- a/src/RaceDirector.Interface/Pipeline/INode.cs
+++ b/src/RaceDirector.Interface/Pipeline/INode.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 
-namespace RaceDirector.Pipeline
+namespace RaceDirector.Pipeline;
+
+/// <summary>
+/// Marker interface to find pipeline nodes.
+/// </summary>
+public interface INode
 {
-    /// <summary>
-    /// Marker interface to find pipeline nodes.
-    /// </summary>
-    public interface INode
-    {
-    }
 }

--- a/src/RaceDirector.Interface/Pipeline/Telemetry/GameTelemetry.cs
+++ b/src/RaceDirector.Interface/Pipeline/Telemetry/GameTelemetry.cs
@@ -5,393 +5,391 @@ using System.Linq;
 using static RaceDirector.Pipeline.Telemetry.V0.IVehicleFlags;
 
 // TODO this is in the interface project to make testing easier, but it might be abused
-namespace RaceDirector.Pipeline.Telemetry
+namespace RaceDirector.Pipeline.Telemetry;
+
+public record GameTelemetry
+(
+    GameState GameState,
+    bool? UsingVR,
+    Event? Event,
+    Session? Session,
+    Vehicle[] Vehicles,
+    Vehicle? FocusedVehicle,
+    Player? Player
+) : IGameTelemetry
 {
+    IEvent? IGameTelemetry.Event => Event;
+    ISession? IGameTelemetry.Session => Session;
+    IVehicle[] IGameTelemetry.Vehicles => Vehicles;
+    IFocusedVehicle? IGameTelemetry.FocusedVehicle => FocusedVehicle;
+    IPlayer? IGameTelemetry.Player => Player;
+}
 
-    public record GameTelemetry
-    (
-        GameState GameState,
-        bool? UsingVR,
-        Event? Event,
-        Session? Session,
-        Vehicle[] Vehicles,
-        Vehicle? FocusedVehicle,
-        Player? Player
-    ) : IGameTelemetry
-    {
-        IEvent? IGameTelemetry.Event => Event;
-        ISession? IGameTelemetry.Session => Session;
-        IVehicle[] IGameTelemetry.Vehicles => Vehicles;
-        IFocusedVehicle? IGameTelemetry.FocusedVehicle => FocusedVehicle;
-        IPlayer? IGameTelemetry.Player => Player;
-    }
+public record Event
+(
+    TrackLayout TrackLayout,
+    // ISessionDuration[] SessionsLength
+    double FuelRate
+) : IEvent
+{
+    ITrackLayout IEvent.TrackLayout => TrackLayout;
+}
 
-    public record Event
-    (
-        TrackLayout TrackLayout,
-        // ISessionDuration[] SessionsLength
-        double FuelRate
-    ) : IEvent
-    {
-        ITrackLayout IEvent.TrackLayout => TrackLayout;
-    }
+public record TrackLayout
+(
+    IFraction<IDistance>[] SectorsEnd
+) : ITrackLayout
+{
+    IFraction<IDistance>[] ITrackLayout.SectorsEnd => SectorsEnd;
+}
 
-    public record TrackLayout
-    (
-        IFraction<IDistance>[] SectorsEnd
-    ) : ITrackLayout
-    {
-        IFraction<IDistance>[] ITrackLayout.SectorsEnd => SectorsEnd;
-    }
+public record Session
+(
+    SessionType Type,
+    SessionPhase Phase,
+    ISessionDuration? Length,
+    SessionRequirements Requirements,
+    ISpeed PitSpeedLimit,
+    bool PitLaneOpen,
+    TimeSpan? ElapsedTime,
+    TimeSpan? TimeRemaining,
+    TimeSpan? WaitTime,
+    StartLights? StartLights,
+    LapTime? BestLap,
+    Sectors? BestSectors,
+    SessionFlags Flags
+) : ISession
+{
+    ISessionRequirements ISession.Requirements => Requirements;
+    IStartLights? ISession.StartLights => StartLights;
+    ILapTime? ISession.BestLap => BestLap;
+    ISectors? ISession.BestSectors => BestSectors;
+    ISessionFlags ISession.Flags => Flags;
+}
 
-    public record Session
-    (
-        SessionType Type,
-        SessionPhase Phase,
-        ISessionDuration? Length,
-        SessionRequirements Requirements,
-        ISpeed PitSpeedLimit,
-        bool PitLaneOpen,
-        TimeSpan? ElapsedTime,
-        TimeSpan? TimeRemaining,
-        TimeSpan? WaitTime,
-        StartLights? StartLights,
-        LapTime? BestLap,
-        Sectors? BestSectors,
-        SessionFlags Flags
-    ) : ISession
-    {
-        ISessionRequirements ISession.Requirements => Requirements;
-        IStartLights? ISession.StartLights => StartLights;
-        ILapTime? ISession.BestLap => BestLap;
-        ISectors? ISession.BestSectors => BestSectors;
-        ISessionFlags ISession.Flags => Flags;
-    }
+public record SessionRequirements
+(
+    uint MandatoryPitStops,
+    MandatoryPitRequirements MandatoryPitRequirements,
+    Interval<IPitWindowBoundary>? PitWindow
+) : ISessionRequirements;
 
-    public record SessionRequirements
-    (
-        uint MandatoryPitStops,
-        MandatoryPitRequirements MandatoryPitRequirements,
-        Interval<IPitWindowBoundary>? PitWindow
-    ) : ISessionRequirements;
+public record StartLights(
+    LightColor Color,
+    BoundedValue<uint> Lit
+) : IStartLights
+{
+    IBoundedValue<uint> IStartLights.Lit => Lit;
+}
 
-    public record StartLights(
-        LightColor Color,
-        BoundedValue<uint> Lit
-    ) : IStartLights
-    {
-        IBoundedValue<uint> IStartLights.Lit => Lit;
-    }
+public record SessionFlags(
+    TrackFlags Track,
+    SectorFlags[] Sectors,
+    LeaderFlags Leader
+) : ISessionFlags;
 
-    public record SessionFlags(
-        TrackFlags Track,
-        SectorFlags[] Sectors,
-        LeaderFlags Leader
-    ) : ISessionFlags;
+public record Vehicle
+(
+    uint Id,
+    int ClassPerformanceIndex,
+    IRacingStatus RacingStatus,
+    EngineType EngineType,
+    ControlType ControlType,
+    uint Position,
+    uint PositionClass,
+    TimeSpan? GapAhead,
+    TimeSpan? GapBehind,
+    uint CompletedLaps,
+    LapValidState LapValid,
+    LapTime? CurrentLapTime,
+    LapTime? PreviousLapTime,
+    LapTime? BestLapTime,
+    Sectors? BestSectors,
+    IFraction<IDistance> CurrentLapDistance,
+    Vector3<IDistance> Location,
+    Orientation? Orientation,
+    ISpeed Speed,
+    Driver CurrentDriver,
+    VehiclePit Pit,
+    Penalty[] Penalties,
+    VehicleFlags Flags,
+    Inputs? Inputs
+) : IFocusedVehicle
+{
+    ILapTime? IVehicle.CurrentLapTime => CurrentLapTime;
+    ILapTime? IVehicle.PreviousLapTime => PreviousLapTime;
+    ILapTime? IVehicle.BestLapTime => BestLapTime;
+    ISectors? IVehicle.BestSectors => BestSectors;
+    IDriver IVehicle.CurrentDriver => CurrentDriver;
+    IVehiclePit IVehicle.Pit => Pit;
+    IVehicleFlags IVehicle.Flags => Flags;
+    IPenalty[] IVehicle.Penalties => Penalties;
+    IInputs? IFocusedVehicle.Inputs => Inputs;
+}
 
-    public record Vehicle
-    (
-        uint Id,
-        int ClassPerformanceIndex,
-        IRacingStatus RacingStatus,
-        EngineType EngineType,
-        ControlType ControlType,
-        uint Position,
-        uint PositionClass,
-        TimeSpan? GapAhead,
-        TimeSpan? GapBehind,
-        uint CompletedLaps,
-        LapValidState LapValid,
-        LapTime? CurrentLapTime,
-        LapTime? PreviousLapTime,
-        LapTime? BestLapTime,
-        Sectors? BestSectors,
-        IFraction<IDistance> CurrentLapDistance,
-        Vector3<IDistance> Location,
-        Orientation? Orientation,
-        ISpeed Speed,
-        Driver CurrentDriver,
-        VehiclePit Pit,
-        Penalty[] Penalties,
-        VehicleFlags Flags,
-        Inputs? Inputs
-    ) : IFocusedVehicle
-    {
-        ILapTime? IVehicle.CurrentLapTime => CurrentLapTime;
-        ILapTime? IVehicle.PreviousLapTime => PreviousLapTime;
-        ILapTime? IVehicle.BestLapTime => BestLapTime;
-        ISectors? IVehicle.BestSectors => BestSectors;
-        IDriver IVehicle.CurrentDriver => CurrentDriver;
-        IVehiclePit IVehicle.Pit => Pit;
-        IVehicleFlags IVehicle.Flags => Flags;
-        IPenalty[] IVehicle.Penalties => Penalties;
-        IInputs? IFocusedVehicle.Inputs => Inputs;
-    }
+public record Driver
+(
+    String Name
+) : IDriver;
 
-    public record Driver
-    (
-        String Name
-    ) : IDriver;
+public record VehiclePit
+(
+    uint StopsDone,
+    uint MandatoryStopsDone,
+    PitLanePhase? PitLanePhase,
+    TimeSpan? PitLaneTime,
+    TimeSpan? PitStallTime
+) : IVehiclePit;
 
-    public record VehiclePit
-    (
-        uint StopsDone,
-        uint MandatoryStopsDone,
-        PitLanePhase? PitLanePhase,
-        TimeSpan? PitLaneTime,
-        TimeSpan? PitStallTime
-    ) : IVehiclePit;
+public record Penalty
+(
+    PenaltyType Type,
+    PenaltyReason Reason
+) : IPenalty;
 
-    public record Penalty
-    (
-        PenaltyType Type,
-        PenaltyReason Reason
-    ) : IPenalty;
+public record Inputs
+(
+    double Throttle,
+    double Brake,
+    double Clutch
+) : IInputs;
 
-    public record Inputs
-    (
-        double Throttle,
-        double Brake,
-        double Clutch
-    ) : IInputs;
+public record VehicleFlags
+(
+    GreenFlag? Green,
+    BlueFlag? Blue,
+    YellowFlag? Yellow,
+    WhiteFlag? White,
+    Flag? Checkered,
+    Flag? Black,
+    BlackWhiteFlag? BlackWhite
+) : IVehicleFlags
+{
+    IGreen? IVehicleFlags.Green => Green;
+    IBlue? IVehicleFlags.Blue => Blue;
+    IYellow? IVehicleFlags.Yellow => Yellow;
+    IWhite? IVehicleFlags.White => White;
+    IFlag? IVehicleFlags.Checkered => Checkered;
+    IFlag? IVehicleFlags.Black => Black;
+    IBlackWhite? IVehicleFlags.BlackWhite => BlackWhite;
+}
 
-    public record VehicleFlags
-    (
-        GreenFlag? Green,
-        BlueFlag? Blue,
-        YellowFlag? Yellow,
-        WhiteFlag? White,
-        Flag? Checkered,
-        Flag? Black,
-        BlackWhiteFlag? BlackWhite
-    ) : IVehicleFlags
-    {
-        IGreen? IVehicleFlags.Green => Green;
-        IBlue? IVehicleFlags.Blue => Blue;
-        IYellow? IVehicleFlags.Yellow => Yellow;
-        IWhite? IVehicleFlags.White => White;
-        IFlag? IVehicleFlags.Checkered => Checkered;
-        IFlag? IVehicleFlags.Black => Black;
-        IBlackWhite? IVehicleFlags.BlackWhite => BlackWhite;
-    }
+public record GreenFlag(GreenReason Reason) : IGreen;
+public record BlueFlag(BlueReason Reason) : IBlue;
+public record YellowFlag(YellowReason Reason) : IYellow;
+public record WhiteFlag(WhiteReason Reason) : IWhite;
+public record BlackWhiteFlag(BlackWhiteReason Reason) : IBlackWhite;
+public record Flag() : IFlag;
 
-    public record GreenFlag(GreenReason Reason) : IGreen;
-    public record BlueFlag(BlueReason Reason) : IBlue;
-    public record YellowFlag(YellowReason Reason) : IYellow;
-    public record WhiteFlag(WhiteReason Reason) : IWhite;
-    public record BlackWhiteFlag(BlackWhiteReason Reason) : IBlackWhite;
-    public record Flag() : IFlag;
+public record Player
+(
+    RawInputs RawInputs,
+    DrivingAids DrivingAids,
+    VehicleSettings VehicleSettings,
+    VehicleDamage VehicleDamage,
+    Tire[][] Tires,
+    Fuel Fuel,
+    Engine Engine,
+    Vector3<IDistance> CgLocation,
+    Orientation Orientation,
+    Vector3<IAcceleration> LocalAcceleration,
+    LapTime? ClassBestLap,
+    Sectors? ClassBestSectors,
+    Sectors? PersonalBestSectors,
+    TimeSpan? PersonalBestDelta,
+    ActivationToggled? Drs,
+    WaitTimeToggled? PushToPass,
+    PlayerPitStop PitStop,
+    PlayerWarnings Warnings,
+    bool? OvertakeAllowed
+) : IPlayer
+{
+    IRawInputs IPlayer.RawInputs => RawInputs;
+    IDrivingAids IPlayer.DrivingAids => DrivingAids;
+    IVehicleSettings IPlayer.VehicleSettings => VehicleSettings;
+    IVehicleDamage IPlayer.VehicleDamage => VehicleDamage;
+    ITire[][] IPlayer.Tires => Tires;
+    IFuel IPlayer.Fuel => Fuel;
+    IEngine IPlayer.Engine => Engine;
+    ILapTime? IPlayer.ClassBestLap => ClassBestLap;
+    ISectors? IPlayer.ClassBestSectors => ClassBestSectors;
+    ISectors? IPlayer.PersonalBestSectors => PersonalBestSectors;
+    IActivationToggled? IPlayer.Drs => Drs;
+    IWaitTimeToggled? IPlayer.PushToPass => PushToPass;
+    PlayerPitStop IPlayer.PitStopStatus => PitStop;
+    IPlayerWarnings IPlayer.Warnings => Warnings;
+}
 
-    public record Player
-    (
-        RawInputs RawInputs,
-        DrivingAids DrivingAids,
-        VehicleSettings VehicleSettings,
-        VehicleDamage VehicleDamage,
-        Tire[][] Tires,
-        Fuel Fuel,
-        Engine Engine,
-        Vector3<IDistance> CgLocation,
-        Orientation Orientation,
-        Vector3<IAcceleration> LocalAcceleration,
-        LapTime? ClassBestLap,
-        Sectors? ClassBestSectors,
-        Sectors? PersonalBestSectors,
-        TimeSpan? PersonalBestDelta,
-        ActivationToggled? Drs,
-        WaitTimeToggled? PushToPass,
-        PlayerPitStop PitStop,
-        PlayerWarnings Warnings,
-        bool? OvertakeAllowed
-    ) : IPlayer
-    {
-        IRawInputs IPlayer.RawInputs => RawInputs;
-        IDrivingAids IPlayer.DrivingAids => DrivingAids;
-        IVehicleSettings IPlayer.VehicleSettings => VehicleSettings;
-        IVehicleDamage IPlayer.VehicleDamage => VehicleDamage;
-        ITire[][] IPlayer.Tires => Tires;
-        IFuel IPlayer.Fuel => Fuel;
-        IEngine IPlayer.Engine => Engine;
-        ILapTime? IPlayer.ClassBestLap => ClassBestLap;
-        ISectors? IPlayer.ClassBestSectors => ClassBestSectors;
-        ISectors? IPlayer.PersonalBestSectors => PersonalBestSectors;
-        IActivationToggled? IPlayer.Drs => Drs;
-        IWaitTimeToggled? IPlayer.PushToPass => PushToPass;
-        PlayerPitStop IPlayer.PitStopStatus => PitStop;
-        IPlayerWarnings IPlayer.Warnings => Warnings;
-    }
+public record RawInputs
+(
+    double Throttle,
+    double Brake,
+    double Clutch,
+    double Steering,
+    IAngle SteerWheelRange
+) : IRawInputs;
 
-    public record RawInputs
-    (
-        double Throttle,
-        double Brake,
-        double Clutch,
-        double Steering,
-        IAngle SteerWheelRange
-    ) : IRawInputs;
+public record DrivingAids(
+    Aid? Abs,
+    TractionControl? Tc,
+    Aid? Esp,
+    Aid? Countersteer,
+    Aid? Cornering
+) : IDrivingAids
+{
+    IAid? IDrivingAids.Abs => Abs;
+    ITractionControl? IDrivingAids.Tc => Tc;
+    IAid? IDrivingAids.Esp => Esp;
+    IAid? IDrivingAids.Countersteer => Countersteer;
+    IAid? IDrivingAids.Cornering => Cornering;
+}
 
-    public record DrivingAids(
-        Aid? Abs,
-        TractionControl? Tc,
-        Aid? Esp,
-        Aid? Countersteer,
-        Aid? Cornering
-    ) : IDrivingAids
-    {
-        IAid? IDrivingAids.Abs => Abs;
-        ITractionControl? IDrivingAids.Tc => Tc;
-        IAid? IDrivingAids.Esp => Esp;
-        IAid? IDrivingAids.Countersteer => Countersteer;
-        IAid? IDrivingAids.Cornering => Cornering;
-    }
+public record TractionControl
+(
+    uint Level,
+    bool Active,
+    uint? Cut
+) : Aid(Level, Active), ITractionControl;
 
-    public record TractionControl
-    (
-        uint Level,
-        bool Active,
-        uint? Cut
-    ) : Aid(Level, Active), ITractionControl;
+public record Aid
+(
+    uint Level,
+    bool Active
+) : IAid;
 
-    public record Aid
-    (
-        uint Level,
-        bool Active
-    ) : IAid;
+public record VehicleSettings
+(
+    uint? EngineMap,
+    uint? EngineBrakeReduction
+) : IVehicleSettings;
 
-    public record VehicleSettings
-    (
-        uint? EngineMap,
-        uint? EngineBrakeReduction
-    ) : IVehicleSettings;
+public record VehicleDamage
+(
+    double AerodynamicsPercent,
+    double EnginePercent,
+    double SuspensionPercent,
+    double TransmissionPercent
+) : IVehicleDamage;
 
-    public record VehicleDamage
-    (
-        double AerodynamicsPercent,
-        double EnginePercent,
-        double SuspensionPercent,
-        double TransmissionPercent
-    ) : IVehicleDamage;
+public record Tire
+(
+    double Dirt,
+    double Grip,
+    double Wear,
+    TemperaturesMatrix Temperatures,
+    TemperaturesSingle BrakeTemperatures
+) : ITire
+{
+    ITemperaturesMatrix ITire.Temperatures => Temperatures;
+    ITemperaturesSingle ITire.BrakeTemperatures => BrakeTemperatures;
+}
 
-    public record Tire
-    (
-        double Dirt,
-        double Grip,
-        double Wear,
-        TemperaturesMatrix Temperatures,
-        TemperaturesSingle BrakeTemperatures
-    ) : ITire
-    {
-        ITemperaturesMatrix ITire.Temperatures => Temperatures;
-        ITemperaturesSingle ITire.BrakeTemperatures => BrakeTemperatures;
-    }
+public record TemperaturesSingle
+(
+    ITemperature CurrentTemperature,
+    ITemperature OptimalTemperature,
+    ITemperature ColdTemperature,
+    ITemperature HotTemperature
+) : ITemperaturesSingle;
 
-    public record TemperaturesSingle
-    (
-        ITemperature CurrentTemperature,
-        ITemperature OptimalTemperature,
-        ITemperature ColdTemperature,
-        ITemperature HotTemperature
-    ) : ITemperaturesSingle;
+public record TemperaturesMatrix
+(
+    ITemperature[][] CurrentTemperatures,
+    ITemperature OptimalTemperature,
+    ITemperature ColdTemperature,
+    ITemperature HotTemperature
+) : ITemperaturesMatrix;
 
-    public record TemperaturesMatrix
-    (
-        ITemperature[][] CurrentTemperatures,
-        ITemperature OptimalTemperature,
-        ITemperature ColdTemperature,
-        ITemperature HotTemperature
-    ) : ITemperaturesMatrix;
+public record Fuel
+(
+    double Max,
+    double Left,
+    double? PerLap
+) : IFuel;
 
-    public record Fuel
-    (
-        double Max,
-        double Left,
-        double? PerLap
-    ) : IFuel;
+public record Engine
+(
+    IAngularSpeed Speed,
+    IAngularSpeed UpshiftSpeed,
+    IAngularSpeed MaxSpeed
+) : IEngine;
 
-    public record Engine
-    (
-        IAngularSpeed Speed,
-        IAngularSpeed UpshiftSpeed,
-        IAngularSpeed MaxSpeed
-    ) : IEngine;
+public record LapTime(
+    TimeSpan Overall,
+    Sectors Sectors
+) : ILapTime
+{
+    ISectors ILapTime.Sectors => Sectors;
+}
 
-    public record LapTime(
-        TimeSpan Overall,
-        Sectors Sectors
-    ) : ILapTime
-    {
-        ISectors ILapTime.Sectors => Sectors;
-    }
+public record Sectors(
+    TimeSpan[] Individual,
+    TimeSpan[] Cumulative
+) : ISectors;
 
-    public record Sectors(
-        TimeSpan[] Individual,
-        TimeSpan[] Cumulative
-    ) : ISectors;
+public record ActivationToggled
+(
+    bool Available,
+    bool Engaged,
+    IBoundedValue<uint>? ActivationsLeft // R3E Drs.NumActivationsLeft + DrsNumActivationsTotal
+) : IActivationToggled;
 
-    public record ActivationToggled
-    (
-        bool Available,
-        bool Engaged,
-        IBoundedValue<uint>? ActivationsLeft // R3E Drs.NumActivationsLeft + DrsNumActivationsTotal
-    ) : IActivationToggled;
+public record WaitTimeToggled
+(
+    bool Available,
+    bool Engaged,
+    IBoundedValue<uint>? ActivationsLeft, // R3E PushToPass.AmountLeft + PtpNumActivationsTotal
+    TimeSpan EngagedTimeLeft,
+    TimeSpan WaitTimeLeft
+) : IWaitTimeToggled;
 
-    public record WaitTimeToggled
-    (
-        bool Available,
-        bool Engaged,
-        IBoundedValue<uint>? ActivationsLeft, // R3E PushToPass.AmountLeft + PtpNumActivationsTotal
-        TimeSpan EngagedTimeLeft,
-        TimeSpan WaitTimeLeft
-    ) : IWaitTimeToggled;
-
-    public record PlayerWarnings
-    (
-        IBoundedValue<uint>? IncidentPoints,
-        IBoundedValue<uint>? BlueFlagWarnings,
-        uint GiveBackPositions
-    ) : IPlayerWarnings;
+public record PlayerWarnings
+(
+    IBoundedValue<uint>? IncidentPoints,
+    IBoundedValue<uint>? BlueFlagWarnings,
+    uint GiveBackPositions
+) : IPlayerWarnings;
 
 public static class DistanceFraction
+{
+    public static IFraction<IDistance> Of(IDistance value, double fraction) =>
+        new OfFraction(value, fraction);
+
+    public static IFraction<IDistance> FromTotal(IDistance total, IDistance value) =>
+        new OfTotalValue(total, value);
+
+    public static IFraction<IDistance> FromTotal(IDistance total, double fraction) =>
+        new OfTotalFraction(total, fraction);
+
+    public static IFraction<IDistance>[] FromTotal(IDistance total, params double[] fractions) =>
+        fractions.Select(f => new OfTotalFraction(total, f)).ToArray();
+
+    private record OfFraction(IDistance Value, double Fraction) : IFraction<IDistance>
     {
-        public static IFraction<IDistance> Of(IDistance value, double fraction) =>
-            new OfFraction(value, fraction);
+        private Lazy<IDistance> _LazyTotal = new Lazy<IDistance>(() => Value / Fraction);
 
-        public static IFraction<IDistance> FromTotal(IDistance total, IDistance value) =>
-            new OfTotalValue(total, value);
-
-        public static IFraction<IDistance> FromTotal(IDistance total, double fraction) =>
-            new OfTotalFraction(total, fraction);
-
-        public static IFraction<IDistance>[] FromTotal(IDistance total, params double[] fractions) =>
-            fractions.Select(f => new OfTotalFraction(total, f)).ToArray();
-
-        private record OfFraction(IDistance Value, double Fraction) : IFraction<IDistance>
-        {
-            private Lazy<IDistance> _LazyTotal = new Lazy<IDistance>(() => Value / Fraction);
-
-            public IDistance Total => _LazyTotal.Value;
-        }
-
-        private record OfTotalFraction(IDistance Total, double Fraction) : IFraction<IDistance>
-        {
-            private Lazy<IDistance> _LazyValue = new Lazy<IDistance>(() => Total * Fraction);
-
-            public IDistance Value => _LazyValue.Value;
-        }
-
-        private record OfTotalValue(IDistance Total, IDistance Value) : IFraction<IDistance>
-        {
-            private Lazy<double> _LazyValue = new Lazy<double>(() => Value / Total);
-
-            public double Fraction => _LazyValue.Value;
-        }
+        public IDistance Total => _LazyTotal.Value;
     }
 
-    public record BoundedValue<T>(T Value, T Total) : IBoundedValue<T>;
-
-    public record RaceInstant(TimeSpan? Time, uint Laps) : IRaceInstant
+    private record OfTotalFraction(IDistance Total, double Fraction) : IFraction<IDistance>
     {
-        public bool IsWithin<T>(Interval<T> boundary) where T : IComparable<IRaceInstant> =>
-            boundary.Start.CompareTo(this) <= 0 && boundary.Finish.CompareTo(this) > 0;
+        private Lazy<IDistance> _LazyValue = new Lazy<IDistance>(() => Total * Fraction);
+
+        public IDistance Value => _LazyValue.Value;
     }
+
+    private record OfTotalValue(IDistance Total, IDistance Value) : IFraction<IDistance>
+    {
+        private Lazy<double> _LazyValue = new Lazy<double>(() => Value / Total);
+
+        public double Fraction => _LazyValue.Value;
+    }
+}
+
+public record BoundedValue<T>(T Value, T Total) : IBoundedValue<T>;
+
+public record RaceInstant(TimeSpan? Time, uint Laps) : IRaceInstant
+{
+    public bool IsWithin<T>(Interval<T> boundary) where T : IComparable<IRaceInstant> =>
+        boundary.Start.CompareTo(this) <= 0 && boundary.Finish.CompareTo(this) > 0;
 }

--- a/src/RaceDirector.Interface/Pipeline/Telemetry/ITelemetryObservableFactory.cs
+++ b/src/RaceDirector.Interface/Pipeline/Telemetry/ITelemetryObservableFactory.cs
@@ -2,10 +2,9 @@
 using RaceDirector.Pipeline.Games;
 using System;
 
-namespace RaceDirector.Pipeline.Telemetry
+namespace RaceDirector.Pipeline.Telemetry;
+
+public interface ITelemetryObservableFactory : IGameInfo
 {
-    public interface ITelemetryObservableFactory : IGameInfo
-    {
-        IObservable<V0.IGameTelemetry> CreateTelemetryObservable();
-    }
+    IObservable<V0.IGameTelemetry> CreateTelemetryObservable();
 }

--- a/src/RaceDirector.Interface/Pipeline/Telemetry/Physics.cs
+++ b/src/RaceDirector.Interface/Pipeline/Telemetry/Physics.cs
@@ -1,254 +1,253 @@
 ﻿using System;
 
-namespace RaceDirector.Pipeline.Telemetry.Physics
+namespace RaceDirector.Pipeline.Telemetry.Physics;
+
+public record Vector3<T>(T X, T Y, T Z);
+
+public interface IDistance
 {
-    public record Vector3<T>(T X, T Y, T Z);
+    private static readonly double KmToMRatio = 1000d;
+    private static readonly double MiToMRatio = 1609.344d;
 
-    public interface IDistance
+    /// <summary>
+    /// Distance in m
+    /// </summary>
+    double M { get; }
+
+    /// <summary>
+    /// Distance in Km
+    /// </summary>
+    double Km { get; }
+
+    /// <summary>
+    /// Distance in mi
+    /// </summary>
+    double Mi { get; }
+
+    IDistance Mul(double factor);
+    IDistance Div(double factor);
+    double Div(IDistance other);
+
+    public static IDistance operator *(IDistance distance, double factor) => distance.Mul(factor);
+    public static IDistance operator /(IDistance distance, double factor) => distance.Div(factor);
+    public static double operator /(IDistance distance, IDistance other) => distance.Div(other);
+
+    public static IDistance FromM(double m) => new DistanceM(m);
+    public static IDistance FromKm(double km) => new DistanceKm(km);
+    public static IDistance FromMi(double mi) => new DistanceMi(mi);
+
+    private record DistanceM(double M) : IDistance
     {
-        private static readonly double KmToMRatio = 1000d;
-        private static readonly double MiToMRatio = 1609.344d;
+        private static readonly double MToKmRatio = 1d / KmToMRatio;
+        private static readonly double MToMiRatio = 1d / MiToMRatio;
 
-        /// <summary>
-        /// Distance in m
-        /// </summary>
-        double M { get; }
+        public double Km => M * MToKmRatio;
+        public double Mi => M * MToMiRatio;
 
-        /// <summary>
-        /// Distance in Km
-        /// </summary>
-        double Km { get; }
-
-        /// <summary>
-        /// Distance in mi
-        /// </summary>
-        double Mi { get; }
-
-        IDistance Mul(double factor);
-        IDistance Div(double factor);
-        double Div(IDistance other);
-
-        public static IDistance operator *(IDistance distance, double factor) => distance.Mul(factor);
-        public static IDistance operator /(IDistance distance, double factor) => distance.Div(factor);
-        public static double operator /(IDistance distance, IDistance other) => distance.Div(other);
-
-        public static IDistance FromM(double m) => new DistanceM(m);
-        public static IDistance FromKm(double km) => new DistanceKm(km);
-        public static IDistance FromMi(double mi) => new DistanceMi(mi);
-
-        private record DistanceM(double M) : IDistance
-        {
-            private static readonly double MToKmRatio = 1d / KmToMRatio;
-            private static readonly double MToMiRatio = 1d / MiToMRatio;
-
-            public double Km => M * MToKmRatio;
-            public double Mi => M * MToMiRatio;
-
-            public IDistance Mul(double factor) => new DistanceM(M * factor);
-            public IDistance Div(double factor) => new DistanceM(M / factor);
-            public double Div(IDistance other) => M / other.M;
-        }
-
-        private record DistanceKm(double Km) : IDistance
-        {
-            private static readonly double KmToMiRatio = KmToMRatio / MiToMRatio;
-
-            public double M => Km * KmToMRatio;
-            public double Mi => Km * KmToMiRatio;
-
-            public IDistance Mul(double factor) => new DistanceKm(Km * factor);
-            public IDistance Div(double factor) => new DistanceKm(Km / factor);
-            public double Div(IDistance other) => Km / other.Km;
-        }
-
-        private record DistanceMi(double Mi) : IDistance
-        {
-            private static readonly double MiToKmRatio = MiToMRatio / KmToMRatio;
-
-            public double M => Mi * MiToMRatio;
-            public double Km => Mi * MiToKmRatio;
-
-            public IDistance Mul(double factor) => new DistanceMi(Mi * factor);
-            public IDistance Div(double factor) => new DistanceMi(Mi / factor);
-            public double Div(IDistance other) => Mi / other.Mi;
-        }
+        public IDistance Mul(double factor) => new DistanceM(M * factor);
+        public IDistance Div(double factor) => new DistanceM(M / factor);
+        public double Div(IDistance other) => M / other.M;
     }
 
-    public interface ISpeed
+    private record DistanceKm(double Km) : IDistance
     {
-        double MPS { get; }
-        double KmPH { get; }
-        double MiPH { get; }
+        private static readonly double KmToMiRatio = KmToMRatio / MiToMRatio;
 
-        static ISpeed FromMPS(double mps) => new Speed(IDistance.FromM(mps), TimeSpan.FromSeconds(1));
-        static ISpeed FromKmPH(double kmPh) => new Speed(IDistance.FromKm(kmPh), TimeSpan.FromHours(1));
-        static ISpeed FromMiPH(double miPh) => new Speed(IDistance.FromMi(miPh), TimeSpan.FromHours(1));
+        public double M => Km * KmToMRatio;
+        public double Mi => Km * KmToMiRatio;
 
-        private class Speed : ISpeed
-        {
-            public Speed(IDistance distance, TimeSpan time)
-            {
-                Distance = distance;
-                Time = time;
-            }
-
-            private readonly IDistance Distance;
-            private readonly TimeSpan Time;
-
-            public double MPS => Distance.M / Time.TotalSeconds;
-            public double KmPH => Distance.Km / Time.TotalHours;
-            public double MiPH => Distance.Mi / Time.TotalHours;
-        }
+        public IDistance Mul(double factor) => new DistanceKm(Km * factor);
+        public IDistance Div(double factor) => new DistanceKm(Km / factor);
+        public double Div(IDistance other) => Km / other.Km;
     }
 
-    public interface IAcceleration
+    private record DistanceMi(double Mi) : IDistance
     {
-        private static readonly double GToMPS2 = 9.80665d;
-        private static readonly double ApproxGToMPS2 = 9.81d;
+        private static readonly double MiToKmRatio = MiToMRatio / KmToMRatio;
 
-        double MPS2 { get; }
-        double G { get; }
-        double ApproxG { get; }
+        public double M => Mi * MiToMRatio;
+        public double Km => Mi * MiToKmRatio;
 
-        static IAcceleration FromMPS2(double value) => new AccelerationMPS2(value);
-        static IAcceleration FromG(double value) => new AccelerationG(value);
-        static IAcceleration FromApproxG(double value) => new AccelerationApproxG(value);
+        public IDistance Mul(double factor) => new DistanceMi(Mi * factor);
+        public IDistance Div(double factor) => new DistanceMi(Mi / factor);
+        public double Div(IDistance other) => Mi / other.Mi;
+    }
+}
 
-        private record AccelerationMPS2(double MPS2) : IAcceleration
+public interface ISpeed
+{
+    double MPS { get; }
+    double KmPH { get; }
+    double MiPH { get; }
+
+    static ISpeed FromMPS(double mps) => new Speed(IDistance.FromM(mps), TimeSpan.FromSeconds(1));
+    static ISpeed FromKmPH(double kmPh) => new Speed(IDistance.FromKm(kmPh), TimeSpan.FromHours(1));
+    static ISpeed FromMiPH(double miPh) => new Speed(IDistance.FromMi(miPh), TimeSpan.FromHours(1));
+
+    private class Speed : ISpeed
+    {
+        public Speed(IDistance distance, TimeSpan time)
         {
-            private static readonly double MPS2ToG = 1d / GToMPS2;
-            private static readonly double MPS2ToApproxG = 1d / ApproxGToMPS2;
-
-            public double G => MPS2 * MPS2ToG;
-            public double ApproxG => MPS2 * MPS2ToApproxG;
+            Distance = distance;
+            Time = time;
         }
 
-        private record AccelerationG(double G) : IAcceleration
-        {
-            private static readonly double GToApproxG = ApproxGToMPS2 / GToMPS2;
+        private readonly IDistance Distance;
+        private readonly TimeSpan Time;
 
-            public double MPS2 => G * GToMPS2;
-            public double ApproxG => G * GToApproxG;
-        }
+        public double MPS => Distance.M / Time.TotalSeconds;
+        public double KmPH => Distance.Km / Time.TotalHours;
+        public double MiPH => Distance.Mi / Time.TotalHours;
+    }
+}
 
-        private record AccelerationApproxG(double ApproxG) : IAcceleration
-        {
-            private static readonly double ApproxGToG = GToMPS2 / ApproxGToMPS2;
+public interface IAcceleration
+{
+    private static readonly double GToMPS2 = 9.80665d;
+    private static readonly double ApproxGToMPS2 = 9.81d;
 
-            public double MPS2 => G * GToMPS2;
-            public double G => ApproxG * ApproxGToG;
-        }
+    double MPS2 { get; }
+    double G { get; }
+    double ApproxG { get; }
+
+    static IAcceleration FromMPS2(double value) => new AccelerationMPS2(value);
+    static IAcceleration FromG(double value) => new AccelerationG(value);
+    static IAcceleration FromApproxG(double value) => new AccelerationApproxG(value);
+
+    private record AccelerationMPS2(double MPS2) : IAcceleration
+    {
+        private static readonly double MPS2ToG = 1d / GToMPS2;
+        private static readonly double MPS2ToApproxG = 1d / ApproxGToMPS2;
+
+        public double G => MPS2 * MPS2ToG;
+        public double ApproxG => MPS2 * MPS2ToApproxG;
     }
 
-    public interface IAngle
+    private record AccelerationG(double G) : IAcceleration
     {
-        private static readonly double RevToRadRatio = 2d * Math.PI;
-        private static readonly double RevToDegRatio = 360d;
+        private static readonly double GToApproxG = ApproxGToMPS2 / GToMPS2;
 
-        /// <summary>
-        /// Angle in degrees.
-        /// </summary>
-        double Deg { get; }
-
-        /// <summary>
-        /// Angle in radians.
-        /// </summary>
-        double Rad { get; }
-
-        /// <summary>
-        /// Complete rotations (AKA revolutions or turns).
-        /// </summary>
-        double Rev { get; }
-
-        static IAngle FromDeg(double value) => new AngleDegrees(value);
-        static IAngle FromRad(double value) => new AngleRadians(value);
-        static IAngle FromRev(double value) => new AngleRevolutions(value);
-
-        private record AngleRadians(double Rad) : IAngle
-        {
-            private static readonly double DegRatio = RevToDegRatio / RevToRadRatio;
-            private static readonly double RevRatio = 1d / RevToRadRatio;
-
-            public double Deg => Rad * DegRatio;
-            public double Rev => Rad * RevRatio;
-        }
-
-        private record AngleDegrees(double Deg) : IAngle
-        {
-            private static readonly double RadRatio = RevToRadRatio / RevToDegRatio;
-            private static readonly double RevRatio = 1d / RevToDegRatio;
-
-            public double Rad => Deg * RadRatio;
-            public double Rev => Deg * RevRatio;
-        }
-
-        private record AngleRevolutions(double Rev) : IAngle
-        {
-            public double Deg => Rev * RevToDegRatio;
-            public double Rad => Rev * RevToRadRatio;
-        }
+        public double MPS2 => G * GToMPS2;
+        public double ApproxG => G * GToApproxG;
     }
 
-    public interface IAngularSpeed
+    private record AccelerationApproxG(double ApproxG) : IAcceleration
     {
-        double RadPS { get; }
-        double RevPS { get; }
+        private static readonly double ApproxGToG = GToMPS2 / ApproxGToMPS2;
 
-        static IAngularSpeed FromRadPS(double value) => new AngularSpeed(IAngle.FromRad(value));
-        static IAngularSpeed FromRevPS(double value) => new AngularSpeed(IAngle.FromRev(value));
+        public double MPS2 => G * GToMPS2;
+        public double G => ApproxG * ApproxGToG;
+    }
+}
 
-        private class AngularSpeed : IAngularSpeed
-        {
-            public AngularSpeed(IAngle angle)
-            {
-                _angle = angle;
-            }
+public interface IAngle
+{
+    private static readonly double RevToRadRatio = 2d * Math.PI;
+    private static readonly double RevToDegRatio = 360d;
 
-            private readonly IAngle _angle;
+    /// <summary>
+    /// Angle in degrees.
+    /// </summary>
+    double Deg { get; }
 
-            public double RadPS => _angle.Rad;
-            public double RevPS => _angle.Rev;
-        }
+    /// <summary>
+    /// Angle in radians.
+    /// </summary>
+    double Rad { get; }
+
+    /// <summary>
+    /// Complete rotations (AKA revolutions or turns).
+    /// </summary>
+    double Rev { get; }
+
+    static IAngle FromDeg(double value) => new AngleDegrees(value);
+    static IAngle FromRad(double value) => new AngleRadians(value);
+    static IAngle FromRev(double value) => new AngleRevolutions(value);
+
+    private record AngleRadians(double Rad) : IAngle
+    {
+        private static readonly double DegRatio = RevToDegRatio / RevToRadRatio;
+        private static readonly double RevRatio = 1d / RevToRadRatio;
+
+        public double Deg => Rad * DegRatio;
+        public double Rev => Rad * RevRatio;
     }
 
-    public record Orientation(
-        IAngle Yaw,
-        IAngle Pitch,
-        IAngle Roll
-    );
-
-    public interface ITemperature
+    private record AngleDegrees(double Deg) : IAngle
     {
-        private static readonly double CToKDiff = 273.15d;
-        private static readonly double CToFDiff = 32d;
-        private static readonly double KCToFRatio = 9d / 5d;
+        private static readonly double RadRatio = RevToRadRatio / RevToDegRatio;
+        private static readonly double RevRatio = 1d / RevToDegRatio;
 
-        double K { get; }
-        double C { get; }
-        double F { get; }
+        public double Rad => Deg * RadRatio;
+        public double Rev => Deg * RevRatio;
+    }
 
-        static ITemperature FromK(double value) => new TemperatureKelvin(value);
-        static ITemperature FromC(double value) => new TemperatureCelsius(value);
-        static ITemperature FromF(double value) => new TemperatureFahrenheit(value);
+    private record AngleRevolutions(double Rev) : IAngle
+    {
+        public double Deg => Rev * RevToDegRatio;
+        public double Rad => Rev * RevToRadRatio;
+    }
+}
 
-        public record TemperatureKelvin(double K) : ITemperature
+public interface IAngularSpeed
+{
+    double RadPS { get; }
+    double RevPS { get; }
+
+    static IAngularSpeed FromRadPS(double value) => new AngularSpeed(IAngle.FromRad(value));
+    static IAngularSpeed FromRevPS(double value) => new AngularSpeed(IAngle.FromRev(value));
+
+    private class AngularSpeed : IAngularSpeed
+    {
+        public AngularSpeed(IAngle angle)
         {
-            public double C => K - CToKDiff;
-            public double F => C * KCToFRatio + CToFDiff;
+            _angle = angle;
         }
 
-        public record TemperatureCelsius(double C) : ITemperature
-        {
-            public double K => C + CToKDiff;
-            public double F => C * KCToFRatio + CToFDiff;
-        }
+        private readonly IAngle _angle;
 
-        public record TemperatureFahrenheit(double F) : ITemperature
-        {
-            private static readonly double FToKCRatio = 1 / KCToFRatio;
+        public double RadPS => _angle.Rad;
+        public double RevPS => _angle.Rev;
+    }
+}
 
-            public double K => C + CToKDiff;
-            public double C => (F - CToFDiff) * FToKCRatio;
-        }
+public record Orientation(
+    IAngle Yaw,
+    IAngle Pitch,
+    IAngle Roll
+);
+
+public interface ITemperature
+{
+    private static readonly double CToKDiff = 273.15d;
+    private static readonly double CToFDiff = 32d;
+    private static readonly double KCToFRatio = 9d / 5d;
+
+    double K { get; }
+    double C { get; }
+    double F { get; }
+
+    static ITemperature FromK(double value) => new TemperatureKelvin(value);
+    static ITemperature FromC(double value) => new TemperatureCelsius(value);
+    static ITemperature FromF(double value) => new TemperatureFahrenheit(value);
+
+    public record TemperatureKelvin(double K) : ITemperature
+    {
+        public double C => K - CToKDiff;
+        public double F => C * KCToFRatio + CToFDiff;
+    }
+
+    public record TemperatureCelsius(double C) : ITemperature
+    {
+        public double K => C + CToKDiff;
+        public double F => C * KCToFRatio + CToFDiff;
+    }
+
+    public record TemperatureFahrenheit(double F) : ITemperature
+    {
+        private static readonly double FToKCRatio = 1 / KCToFRatio;
+
+        public double K => C + CToKDiff;
+        public double C => (F - CToFDiff) * FToKCRatio;
     }
 }

--- a/src/RaceDirector.Plugin/DependencyInjection.cs
+++ b/src/RaceDirector.Plugin/DependencyInjection.cs
@@ -1,42 +1,41 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using System;
 
-namespace RaceDirector.DependencyInjection
+namespace RaceDirector.DependencyInjection;
+
+public static class ServiceCollectionServiceExtensions
 {
-    public static class ServiceCollectionServiceExtensions
+    public static IServiceCollection AddSingletonWithInterfaces<TService>(this IServiceCollection services, Func<IServiceProvider, TService> implementationFactory)
+        where TService : class
     {
-        public static IServiceCollection AddSingletonWithInterfaces<TService>(this IServiceCollection services, Func<IServiceProvider, TService> implementationFactory)
-            where TService : class
-        {
-            return services.AddSingleton(implementationFactory).AddInterfaces<TService>();
-        }
+        return services.AddSingleton(implementationFactory).AddInterfaces<TService>();
+    }
 
-        public static IServiceCollection AddSingletonWithInterfaces<TService>(this IServiceCollection services)
-    where TService : class
-        {
-            return services.AddSingleton<TService>().AddInterfaces<TService>();
-        }
+    public static IServiceCollection AddSingletonWithInterfaces<TService>(this IServiceCollection services)
+        where TService : class
+    {
+        return services.AddSingleton<TService>().AddInterfaces<TService>();
+    }
 
-        public static IServiceCollection AddTransientWithInterfaces<TService>(this IServiceCollection services, Func<IServiceProvider, TService> implementationFactory)
-            where TService : class
-        {
-            return services.AddTransient(implementationFactory).AddInterfaces<TService>();
-        }
+    public static IServiceCollection AddTransientWithInterfaces<TService>(this IServiceCollection services, Func<IServiceProvider, TService> implementationFactory)
+        where TService : class
+    {
+        return services.AddTransient(implementationFactory).AddInterfaces<TService>();
+    }
 
-        public static IServiceCollection AddTransientWithInterfaces<TService>(this IServiceCollection services)
-            where TService : class
-        {
-            return services.AddTransient<TService>().AddInterfaces<TService>();
-        }
+    public static IServiceCollection AddTransientWithInterfaces<TService>(this IServiceCollection services)
+        where TService : class
+    {
+        return services.AddTransient<TService>().AddInterfaces<TService>();
+    }
 
-        public static IServiceCollection AddInterfaces<TService>(this IServiceCollection services)
-            where TService : class
+    public static IServiceCollection AddInterfaces<TService>(this IServiceCollection services)
+        where TService : class
+    {
+        foreach (var i in typeof(TService).GetInterfaces())
         {
-            foreach (var i in typeof(TService).GetInterfaces())
-            {
-                services.AddTransient(i, s => s.GetRequiredService<TService>());
-            }
-            return services;
+            services.AddTransient(i, s => s.GetRequiredService<TService>());
         }
+        return services;
     }
 }

--- a/src/RaceDirector.Plugin/IPlugin.cs
+++ b/src/RaceDirector.Plugin/IPlugin.cs
@@ -1,10 +1,9 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace RaceDirector.Plugin
+namespace RaceDirector.Plugin;
+
+public interface IPlugin
 {
-    public interface IPlugin
-    {
-        void Init(IConfiguration configuration, IServiceCollection services);
-    }
+    void Init(IConfiguration configuration, IServiceCollection services);
 }

--- a/src/RaceDirector.Plugin/PluginBase.cs
+++ b/src/RaceDirector.Plugin/PluginBase.cs
@@ -1,19 +1,18 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace RaceDirector.Plugin
+namespace RaceDirector.Plugin;
+
+public abstract class PluginBase<TConfig> : IPlugin
 {
-    public abstract class PluginBase<TConfig> : IPlugin
+    public string Name => GetType().FullName;
+
+    public void Init(IConfiguration configuration, IServiceCollection services)
     {
-        public string Name => GetType().FullName;
-
-        public void Init(IConfiguration configuration, IServiceCollection services)
-        {
-            var configSection = configuration.GetSection(Name);
-            var pluginConfig = configSection.Get<TConfig>();
-            Init(pluginConfig, services);
-        }
-
-        protected abstract void Init(TConfig pluginConfig, IServiceCollection services);
+        var configSection = configuration.GetSection(Name);
+        var pluginConfig = configSection.Get<TConfig>();
+        Init(pluginConfig, services);
     }
+
+    protected abstract void Init(TConfig pluginConfig, IServiceCollection services);
 }

--- a/src/RaceDirector/Pipeline/GameMonitor/KeepOne.cs
+++ b/src/RaceDirector/Pipeline/GameMonitor/KeepOne.cs
@@ -1,41 +1,40 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 
-namespace RaceDirector.Pipeline.GameMonitor
+namespace RaceDirector.Pipeline.GameMonitor;
+
+public class KeepOne<T> where T : class
 {
-    public class KeepOne<T> where T : class
+    private readonly IEnumerable<T> _options;
+    private T? _current;
+
+    private static readonly IEnumerable<T> NoOutput = Enumerable.Empty<T>();
+
+    public KeepOne(IEnumerable<T> options)
     {
-        private readonly IEnumerable<T> _options;
-        private T? _current;
+        _options = options;
+    }
 
-        private static readonly IEnumerable<T> NoOutput = Enumerable.Empty<T>();
+    public IEnumerable<T?> Call(IEnumerable<T> input)
+    {
+        if (input.Contains(_current))
+            return NoOutput;
 
-        public KeepOne(IEnumerable<T> options)
+        var matching = input.Intersect(_options);
+
+        if (matching.Any())
         {
-            _options = options;
+            _current = matching.First();
+            return new[] { _current };
         }
-
-        public IEnumerable<T?> Call(IEnumerable<T> input)
+        else if (_current is not null)
         {
-            if (input.Contains(_current))
-                return NoOutput;
-
-            var matching = input.Intersect(_options);
-
-            if (matching.Any())
-            {
-                _current = matching.First();
-                return new[] { _current };
-            }
-            else if (_current is not null)
-            {
-                _current = null;
-                return new[] { _current };
-            }
-            else
-            {
-                return NoOutput;
-            }
+            _current = null;
+            return new[] { _current };
+        }
+        else
+        {
+            return NoOutput;
         }
     }
 }

--- a/src/RaceDirector/Pipeline/GameMonitor/ProcessMonitorNode.cs
+++ b/src/RaceDirector/Pipeline/GameMonitor/ProcessMonitorNode.cs
@@ -6,65 +6,64 @@ using System.Linq;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 
-namespace RaceDirector.Pipeline.GameMonitor
+namespace RaceDirector.Pipeline.GameMonitor;
+
+public class ProcessMonitorNode : INode
 {
-    public class ProcessMonitorNode : INode
+    private readonly ILogger<ProcessMonitorNode> _logger;
+
+    public class Config
     {
-        private readonly ILogger<ProcessMonitorNode> _logger;
+        public TimeSpan PollingInterval { get; set; }
+    }
 
-        public class Config
-        {
-            public TimeSpan PollingInterval { get; set; }
-        }
+    public IObservable<RunningGame> RunningGameObservable => _lazyRunningGameObservable.Value;
 
-        public IObservable<RunningGame> RunningGameObservable => _lazyRunningGameObservable.Value;
+    private readonly Lazy<IObservable<RunningGame>> _lazyRunningGameObservable;
 
-        private readonly Lazy<IObservable<RunningGame>> _lazyRunningGameObservable;
+    public ProcessMonitorNode(ILogger<ProcessMonitorNode> logger, Config config, IEnumerable<IGameProcessInfo> gameProcessInfos)
+    {
+        _logger = logger;
+        _lazyRunningGameObservable =
+            new Lazy<IObservable<RunningGame>>(() => GameProcessPoller(config, gameProcessInfos).Publish().RefCount());
+    }
 
-        public ProcessMonitorNode(ILogger<ProcessMonitorNode> logger, Config config, IEnumerable<IGameProcessInfo> gameProcessInfos)
-        {
-            _logger = logger;
-            _lazyRunningGameObservable =
-                new Lazy<IObservable<RunningGame>>(() => GameProcessPoller(config, gameProcessInfos).Publish().RefCount());
-        }
+    private IObservable<RunningGame> GameProcessPoller(Config config, IEnumerable<IGameProcessInfo> gameProcessInfos)
+    {
+        // TODO Write this in a simpler way
+        // TODO Add BehaviorSubject to emit latest element on subscribe or support ConnectableObservables in the framework?
+        Dictionary<string, string> gameByProcess = GameByProcess(gameProcessInfos);
+        Func<IEnumerable<string>, IEnumerable<string?>> keepOne = new KeepOne<string>(gameByProcess.Keys).Call;
 
-        private IObservable<RunningGame> GameProcessPoller(Config config, IEnumerable<IGameProcessInfo> gameProcessInfos)
-        {
-            // TODO Write this in a simpler way
-            // TODO Add BehaviorSubject to emit latest element on subscribe or support ConnectableObservables in the framework?
-            Dictionary<string, string> gameByProcess = GameByProcess(gameProcessInfos);
-            Func<IEnumerable<string>, IEnumerable<string?>> keepOne = new KeepOne<string>(gameByProcess.Keys).Call;
-
-            return ObservableInterval(config)
-                .Select(_ => CurrentProcessNames())
-                .SelectMany(processNames =>
-                    keepOne(processNames).Select(processName =>
+        return ObservableInterval(config)
+            .Select(_ => CurrentProcessNames())
+            .SelectMany(processNames =>
+                keepOne(processNames).Select(processName =>
+                {
+                    if (processName == null)
                     {
-                        if (processName == null)
-                        {
-                            _logger.LogInformation("The game has been closed");
-                            return new RunningGame(null);
-                        }
+                        _logger.LogInformation("The game has been closed");
+                        return new RunningGame(null);
+                    }
 
-                        var game = gameByProcess.GetValueOrDefault(processName);
-                        _logger.LogInformation("Found game {string?} (process {string?})", game, processName);
-                        return new RunningGame(game);
-                    })
-                );
-        }
+                    var game = gameByProcess.GetValueOrDefault(processName);
+                    _logger.LogInformation("Found game {string?} (process {string?})", game, processName);
+                    return new RunningGame(game);
+                })
+            );
+    }
 
-        // The Rx.NET framework is not easily testable
-        protected virtual IObservable<long> ObservableInterval(Config config) =>
-            Observable.Interval(config.PollingInterval);
+    // The Rx.NET framework is not easily testable
+    protected virtual IObservable<long> ObservableInterval(Config config) =>
+        Observable.Interval(config.PollingInterval);
 
-        protected virtual IEnumerable<string> CurrentProcessNames() =>
-            Process.GetProcesses().Select(p => p.ProcessName);
+    protected virtual IEnumerable<string> CurrentProcessNames() =>
+        Process.GetProcesses().Select(p => p.ProcessName);
 
-        private static Dictionary<string, string> GameByProcess(IEnumerable<IGameProcessInfo> gameProcessInfos)
-        {
-            return gameProcessInfos
-                .SelectMany(gpi => gpi.GameProcessNames.Select(p => KeyValuePair.Create(p, gpi.GameName)))
-                .ToDictionary(x => x.Key, x => x.Value);
-        }
+    private static Dictionary<string, string> GameByProcess(IEnumerable<IGameProcessInfo> gameProcessInfos)
+    {
+        return gameProcessInfos
+            .SelectMany(gpi => gpi.GameProcessNames.Select(p => KeyValuePair.Create(p, gpi.GameName)))
+            .ToDictionary(x => x.Key, x => x.Value);
     }
 }

--- a/src/RaceDirector/Pipeline/Games/ACC/Game.cs
+++ b/src/RaceDirector/Pipeline/Games/ACC/Game.cs
@@ -4,52 +4,51 @@ using System.Reactive.Linq;
 using System.Runtime.Versioning;
 using RaceDirector.Pipeline.Telemetry.V0;
 
-namespace RaceDirector.Pipeline.Games.ACC
+namespace RaceDirector.Pipeline.Games.ACC;
+
+[SupportedOSPlatform("windows")]
+public class Game : IGame
 {
-    [SupportedOSPlatform("windows")]
-    public class Game : IGame
+    public class Config
     {
-        public class Config
-        {
-            public TimeSpan PollingInterval { get; set; }
-        }
-
-        private readonly Config _config;
-
-        public string GameName => "ACC";
-
-        public string[] GameProcessNames => new[] { "AC2-Win64-Shipping" };
-
-        public Game(Config config)
-        {
-            _config = config;
-        }
-
-        public IObservable<IGameTelemetry> CreateTelemetryObservable()
-        {
-            var physicsMmReader = new MemoryMappedFileReader<Contrib.Data.SPageFilePhysics>(Contrib.Constant.SharedMemoryPhysicsName);
-            var graphicMmReader = new MemoryMappedFileReader<Contrib.Data.SPageFileGraphic>(Contrib.Constant.SharedMemoryGraphicName);
-            var staticMmReader = new MemoryMappedFileReader<Contrib.Data.SPageFileStatic>(Contrib.Constant.SharedMemoryStaticName);
-            var telemetryConverter = new TelemetryConverter();
-            return Observable.Interval(_config.PollingInterval)
-                .SelectMany(_ =>
-                {
-                    try
-                    {
-                        Contrib.Data.Shared shared;
-                        shared.Physics = physicsMmReader.Read();
-                        shared.Graphic = graphicMmReader.Read();
-                        shared.Static = staticMmReader.Read();
-                        var telemetry = telemetryConverter.Transform(ref shared);
-                        return Observable.Return(telemetry);
-                    }
-                    catch
-                    {
-                        return Observable.Empty<IGameTelemetry>();
-                    }
-                });
-        }
-
-
+        public TimeSpan PollingInterval { get; set; }
     }
+
+    private readonly Config _config;
+
+    public string GameName => "ACC";
+
+    public string[] GameProcessNames => new[] { "AC2-Win64-Shipping" };
+
+    public Game(Config config)
+    {
+        _config = config;
+    }
+
+    public IObservable<IGameTelemetry> CreateTelemetryObservable()
+    {
+        var physicsMmReader = new MemoryMappedFileReader<Contrib.Data.SPageFilePhysics>(Contrib.Constant.SharedMemoryPhysicsName);
+        var graphicMmReader = new MemoryMappedFileReader<Contrib.Data.SPageFileGraphic>(Contrib.Constant.SharedMemoryGraphicName);
+        var staticMmReader = new MemoryMappedFileReader<Contrib.Data.SPageFileStatic>(Contrib.Constant.SharedMemoryStaticName);
+        var telemetryConverter = new TelemetryConverter();
+        return Observable.Interval(_config.PollingInterval)
+            .SelectMany(_ =>
+            {
+                try
+                {
+                    Contrib.Data.Shared shared;
+                    shared.Physics = physicsMmReader.Read();
+                    shared.Graphic = graphicMmReader.Read();
+                    shared.Static = staticMmReader.Read();
+                    var telemetry = telemetryConverter.Transform(ref shared);
+                    return Observable.Return(telemetry);
+                }
+                catch
+                {
+                    return Observable.Empty<IGameTelemetry>();
+                }
+            });
+    }
+
+
 }

--- a/src/RaceDirector/Pipeline/Games/ACC/TelemetryConverter.cs
+++ b/src/RaceDirector/Pipeline/Games/ACC/TelemetryConverter.cs
@@ -3,321 +3,320 @@ using RaceDirector.Pipeline.Telemetry.Physics;
 using RaceDirector.Pipeline.Telemetry.V0;
 using System;
 
-namespace RaceDirector.Pipeline.Games.ACC
+namespace RaceDirector.Pipeline.Games.ACC;
+
+internal class TelemetryConverter
 {
-    internal class TelemetryConverter
+    private static GameTelemetry NoMMFiles = new(
+        GameState: GameState.Menu,
+        UsingVR: null,
+        Event: null,
+        Session: null,
+        Vehicles: Array.Empty<Vehicle>(),
+        FocusedVehicle: null,
+        Player: null
+    );
+
+    internal GameTelemetry Transform(ref Contrib.Data.Shared sharedData)
     {
-        private static GameTelemetry NoMMFiles = new(
-            GameState: GameState.Menu,
-            UsingVR: null,
-            Event: null,
-            Session: null,
-            Vehicles: Array.Empty<Vehicle>(),
-            FocusedVehicle: null,
-            Player: null
+        if (sharedData.Static.SmVersion.Length == 0)
+            return NoMMFiles;
+        var smVersionMajor = Int32.Parse(sharedData.Static.SmVersion.Split('.')[0]);
+        if (smVersionMajor != Contrib.Constant.SmVersionMajor)
+            throw new ArgumentException("Incompatible major version");
+        return new GameTelemetry(
+            GameState: ToGameState(ref sharedData),
+            UsingVR: null, // TODO Check if it can be inferred from process parameters
+            Event: ToEvent(ref sharedData),
+            Session: ToSession(ref sharedData),
+            Vehicles: ToVehicles(ref sharedData),
+            FocusedVehicle: ToFocusedVehicle(ref sharedData),
+            Player: ToPlayer(ref sharedData)
         );
+    }
 
-        internal GameTelemetry Transform(ref Contrib.Data.Shared sharedData)
+    private static GameState ToGameState(ref Contrib.Data.Shared sharedData)
+    {
+        return sharedData.Graphic.Status switch
         {
-            if (sharedData.Static.SmVersion.Length == 0)
-                return NoMMFiles;
-            var smVersionMajor = Int32.Parse(sharedData.Static.SmVersion.Split('.')[0]);
-            if (smVersionMajor != Contrib.Constant.SmVersionMajor)
-                throw new ArgumentException("Incompatible major version");
-            return new GameTelemetry(
-                GameState: ToGameState(ref sharedData),
-                UsingVR: null, // TODO Check if it can be inferred from process parameters
-                Event: ToEvent(ref sharedData),
-                Session: ToSession(ref sharedData),
-                Vehicles: ToVehicles(ref sharedData),
-                FocusedVehicle: ToFocusedVehicle(ref sharedData),
-                Player: ToPlayer(ref sharedData)
-            );
-        }
-
-        private static GameState ToGameState(ref Contrib.Data.Shared sharedData)
-        {
-            return sharedData.Graphic.Status switch
-            {
-                Contrib.Constant.Status.Off => GameState.Replay, // recorded replay
-                Contrib.Constant.Status.Replay => GameState.Replay, // in-game replay
-                Contrib.Constant.Status.Live when sharedData.Physics.WaterTemp == 0 => GameState.Menu, // in-game menu
-                Contrib.Constant.Status.Live => GameState.Driving,
-                Contrib.Constant.Status.Pause => GameState.Paused, // single player game paused
-                _ => throw new ArgumentException("Unknown game state")
-            };
-        }
-
-        private static Event? ToEvent(ref Contrib.Data.Shared sharedData)
-        {
-            return new Event(
-                TrackLayout: new TrackLayout
-                (
-                    // Sector length can be inferred from TrackData.TrackMeters (UDP)
-                    // and SPageFileGraphic.NormalizedCarPosition (MM). Sectors in SM
-                    // are considered 1/3 of the total length, but that is incorrect.
-                    // Will have to record them on track and save them in config.
-                    SectorsEnd: Array.Empty<IFraction<IDistance>>() // TODO
-                ),
-                FuelRate: sharedData.Static.AidFuelRate
-            );
-        }
-
-        private static Session? ToSession(ref Contrib.Data.Shared sharedData)
-        {
-            var maybeSessionType = ToSessionType(sharedData.Graphic.Session);
-            if (maybeSessionType is null)
-                return null;
-
-            return new Session
-            (
-                Type: maybeSessionType.Value,
-                // It might be inferred from global flags, timers, etc.
-                Phase: SessionPhase.Unknown, // TODO
-                // Practice: timed (in race) or unlimited (SessionTimeLeft -1)
-                // Hotlap: unlimited
-                // HotstintSuperpole: 2 laps
-                // Hotstint: timed
-                // Qualify: timed
-                // Race: timed
-                Length: new RaceDuration.LapsDuration(10, null), // TODO
-                Requirements: new SessionRequirements // TODO
-                (
-                    0, MandatoryPitRequirements.None,
-                    new Interval<IPitWindowBoundary>
-                    (
-                        new RaceDuration.LapsDuration(Laps: Convert.ToUInt32(0), EstimatedTime: null),
-                        new RaceDuration.LapsDuration(Laps: Convert.ToUInt32(0), EstimatedTime: null)
-                    )
-                ),
-                PitSpeedLimit: ISpeed.FromMPS(0), // TODO
-                PitLaneOpen: true, // TODO
-                ElapsedTime: TimeSpan.Zero, // TODO
-                TimeRemaining: TimeSpan.Zero, // TODO
-                WaitTime: TimeSpan.Zero, // TODO
-                StartLights: new StartLights // TODO
-                (
-                    Color: LightColor.Green,
-                    Lit: new BoundedValue<uint>(0, 4)
-                ),
-                BestLap: null, // TODO
-                BestSectors: null, // TODO
-                Flags: new SessionFlags // TODO
-                (
-                    Track: TrackFlags.None,
-                    Sectors: new SectorFlags[0],
-                    Leader: LeaderFlags.None
-                )
-            );
-        }
-
-        private static SessionType? ToSessionType(Contrib.Constant.SessionType session) => session switch
-        {
-            Contrib.Constant.SessionType.Practice => SessionType.Practice,
-            Contrib.Constant.SessionType.Qualify => SessionType.Qualify,
-            Contrib.Constant.SessionType.Race => SessionType.Race,
-            Contrib.Constant.SessionType.Hotlap => SessionType.HotLap,
-            Contrib.Constant.SessionType.Timeattack => SessionType.TimeAttack,
-            Contrib.Constant.SessionType.Drift => SessionType.Drift,
-            Contrib.Constant.SessionType.Drag => SessionType.Drag,
-            Contrib.Constant.SessionType.Hotstint => SessionType.HotStint,
-            Contrib.Constant.SessionType.HotstintSuperpole => SessionType.HotStintSuperPole,
-            _ => null
+            Contrib.Constant.Status.Off => GameState.Replay, // recorded replay
+            Contrib.Constant.Status.Replay => GameState.Replay, // in-game replay
+            Contrib.Constant.Status.Live when sharedData.Physics.WaterTemp == 0 => GameState.Menu, // in-game menu
+            Contrib.Constant.Status.Live => GameState.Driving,
+            Contrib.Constant.Status.Pause => GameState.Paused, // single player game paused
+            _ => throw new ArgumentException("Unknown game state")
         };
+    }
 
-        private static Vehicle[] ToVehicles(ref Contrib.Data.Shared sharedData)
-        {
-            return Array.Empty<Vehicle>();
-        }
-
-        private static Vehicle? ToVehicle(ref Contrib.Data.Shared sharedData)
-        {
-            return new Vehicle
+    private static Event? ToEvent(ref Contrib.Data.Shared sharedData)
+    {
+        return new Event(
+            TrackLayout: new TrackLayout
             (
-                Id: 0, // TODO // TODO
-                ClassPerformanceIndex: -1, // TODO
-                RacingStatus: IRacingStatus.Unknown, // TODO
-                EngineType: EngineType.Unknown, // TODO
-                ControlType: ControlType.LocalPlayer, // TODO
-                Position: 0, // TODO
-                PositionClass: 0, // TODO
-                GapAhead: null, // TODO
-                GapBehind: null, // TODO
-                CompletedLaps: 0, // TODO
-                LapValid: LapValidState.Unknown, // TODO
-                CurrentLapTime: null, // TODO
-                PreviousLapTime: null, // TODO
-                BestLapTime: null, // TODO
-                BestSectors: null, // TODO
-                CurrentLapDistance: DistanceFraction.Of(IDistance.FromM(1), 0), // TODO
-                Location: new Vector3<IDistance> // TODO
-                (
-                    X: IDistance.FromM(0),
-                    Y: IDistance.FromM(0),
-                    Z: IDistance.FromM(0)
-                ),
-                Orientation: null, // TODO
-                Speed: ISpeed.FromMPS(0), // TODO
-                CurrentDriver: new Driver // TODO
-                (
-                    Name: ""
-                ),
-                Pit: new VehiclePit // TODO
-                (
-                    StopsDone: 0,
-                    MandatoryStopsDone: 0,
-                    PitLanePhase: null,
-                    PitLaneTime: null,
-                    PitStallTime: null
-                ),
-                Penalties: Array.Empty<Penalty>(), // TODO
-                Flags: new VehicleFlags // TODO
-                (
-                    Green: null,
-                    Blue: null,
-                    Yellow: null,
-                    White: null,
-                    Checkered: null,
-                    Black: null,
-                    BlackWhite: null
-                ),
-                Inputs: null // TODO
-            );
-        }
+                // Sector length can be inferred from TrackData.TrackMeters (UDP)
+                // and SPageFileGraphic.NormalizedCarPosition (MM). Sectors in SM
+                // are considered 1/3 of the total length, but that is incorrect.
+                // Will have to record them on track and save them in config.
+                SectorsEnd: Array.Empty<IFraction<IDistance>>() // TODO
+            ),
+            FuelRate: sharedData.Static.AidFuelRate
+        );
+    }
 
-        private static Vehicle? ToFocusedVehicle(ref Contrib.Data.Shared sharedData)
-        {
-            return new Vehicle
-            (
-                Id: 0, // TODO // TODO
-                ClassPerformanceIndex: -1, // TODO
-                RacingStatus: IRacingStatus.Unknown, // TODO
-                EngineType: EngineType.Unknown, // TODO
-                ControlType: ControlType.LocalPlayer, // TODO
-                Position: 0, // TODO
-                PositionClass: 0, // TODO
-                GapAhead: null, // TODO
-                GapBehind: null, // TODO
-                CompletedLaps: 0, // TODO
-                LapValid: LapValidState.Unknown, // TODO
-                CurrentLapTime: null, // TODO
-                PreviousLapTime : null, // TODO
-                BestLapTime : null, // TODO
-                BestSectors : null, // TODO
-                CurrentLapDistance: DistanceFraction.Of(IDistance.FromM(1), 0), // TODO
-                Location: new Vector3<IDistance> // TODO
-                (
-                    X: IDistance.FromM(0),
-                    Y: IDistance.FromM(0),
-                    Z: IDistance.FromM(0)
-                ),
-                Orientation: null, // TODO
-                Speed: ISpeed.FromMPS(0), // TODO
-                CurrentDriver: new Driver // TODO
-                (
-                    Name:  ""
-                ),
-                Pit: new VehiclePit // TODO
-                (
-                    StopsDone: 0,
-                    MandatoryStopsDone: 0,
-                    PitLanePhase: null,
-                    PitLaneTime: null,
-                    PitStallTime: null
-                ),
-                Penalties: Array.Empty<Penalty>(), // TODO
-                Flags: new VehicleFlags // TODO
-                (
-                    Green : null,
-                    Blue : null,
-                    Yellow : null,
-                    White : null,
-                    Checkered : null,
-                    Black : null,
-                    BlackWhite : null
-                ),
-                Inputs: null // TODO
-            );
-        }
+    private static Session? ToSession(ref Contrib.Data.Shared sharedData)
+    {
+        var maybeSessionType = ToSessionType(sharedData.Graphic.Session);
+        if (maybeSessionType is null)
+            return null;
 
-        private static Player? ToPlayer(ref Contrib.Data.Shared sharedData)
-        {
-            return new Player
+        return new Session
+        (
+            Type: maybeSessionType.Value,
+            // It might be inferred from global flags, timers, etc.
+            Phase: SessionPhase.Unknown, // TODO
+            // Practice: timed (in race) or unlimited (SessionTimeLeft -1)
+            // Hotlap: unlimited
+            // HotstintSuperpole: 2 laps
+            // Hotstint: timed
+            // Qualify: timed
+            // Race: timed
+            Length: new RaceDuration.LapsDuration(10, null), // TODO
+            Requirements: new SessionRequirements // TODO
             (
-                RawInputs: new RawInputs // TODO
+                0, MandatoryPitRequirements.None,
+                new Interval<IPitWindowBoundary>
                 (
-                    Throttle: 0,
-                    Brake: 0,
-                    Clutch: 0,
-                    Steering: 0,
-                    SteerWheelRange: IAngle.FromDeg(0)
-                ),
-                DrivingAids: new DrivingAids // TODO
-                (
-                    Abs: null,
-                    Tc: null,
-                    Esp: null,
-                    Countersteer: null,
-                    Cornering: null
-                ),
-                VehicleSettings: new VehicleSettings // TODO
-                (
-                    EngineMap: null,
-                    EngineBrakeReduction: null
-                ),
-                VehicleDamage: new VehicleDamage // TODO
-                (
-                    AerodynamicsPercent: 0,
-                    EnginePercent: 0,
-                    SuspensionPercent: 0,
-                    TransmissionPercent: 0
-                ),
-                Tires: Array.Empty<Tire[]>(),
-                Fuel: new Fuel // TODO
-                (
-                    Max: 0,
-                    Left: 0,
-                    PerLap: null
-                ),
-                Engine: new Engine // TODO
-                (
-                    Speed: IAngularSpeed.FromRevPS(0),
-                    UpshiftSpeed: IAngularSpeed.FromRevPS(0),
-                    MaxSpeed: IAngularSpeed.FromRevPS(0)
-                ),
-                CgLocation: new Vector3<IDistance> // TODO
-                (
-                    X: IDistance.FromM(0),
-                    Y: IDistance.FromM(0),
-                    Z: IDistance.FromM(0)
-                ),
-                Orientation: new Orientation // TODO
-                (
-                    Yaw: IAngle.FromDeg(0),
-                    Pitch: IAngle.FromDeg(0),
-                    Roll: IAngle.FromDeg(0)
-                ),
-                LocalAcceleration: new Vector3<IAcceleration> // TODO
-                (
-                    X: IAcceleration.FromMPS2(0),
-                    Y: IAcceleration.FromMPS2(0),
-                    Z: IAcceleration.FromMPS2(0)
-                ),
-                ClassBestLap: null,
-                ClassBestSectors: null, // TODO
-                PersonalBestSectors: null, // TODO
-                PersonalBestDelta: null, // TODO
-                Drs: null, // TODO
-                PushToPass: null, // TODO
-                PitStop: PlayerPitStop.None,
-                Warnings: new PlayerWarnings // TODO
-                (
-                    IncidentPoints: null,
-                    BlueFlagWarnings: null,
-                    GiveBackPositions: 0
-                ),
-                OvertakeAllowed: null // TODO
-            );
-        }
+                    new RaceDuration.LapsDuration(Laps: Convert.ToUInt32(0), EstimatedTime: null),
+                    new RaceDuration.LapsDuration(Laps: Convert.ToUInt32(0), EstimatedTime: null)
+                )
+            ),
+            PitSpeedLimit: ISpeed.FromMPS(0), // TODO
+            PitLaneOpen: true, // TODO
+            ElapsedTime: TimeSpan.Zero, // TODO
+            TimeRemaining: TimeSpan.Zero, // TODO
+            WaitTime: TimeSpan.Zero, // TODO
+            StartLights: new StartLights // TODO
+            (
+                Color: LightColor.Green,
+                Lit: new BoundedValue<uint>(0, 4)
+            ),
+            BestLap: null, // TODO
+            BestSectors: null, // TODO
+            Flags: new SessionFlags // TODO
+            (
+                Track: TrackFlags.None,
+                Sectors: new SectorFlags[0],
+                Leader: LeaderFlags.None
+            )
+        );
+    }
+
+    private static SessionType? ToSessionType(Contrib.Constant.SessionType session) => session switch
+    {
+        Contrib.Constant.SessionType.Practice => SessionType.Practice,
+        Contrib.Constant.SessionType.Qualify => SessionType.Qualify,
+        Contrib.Constant.SessionType.Race => SessionType.Race,
+        Contrib.Constant.SessionType.Hotlap => SessionType.HotLap,
+        Contrib.Constant.SessionType.Timeattack => SessionType.TimeAttack,
+        Contrib.Constant.SessionType.Drift => SessionType.Drift,
+        Contrib.Constant.SessionType.Drag => SessionType.Drag,
+        Contrib.Constant.SessionType.Hotstint => SessionType.HotStint,
+        Contrib.Constant.SessionType.HotstintSuperpole => SessionType.HotStintSuperPole,
+        _ => null
+    };
+
+    private static Vehicle[] ToVehicles(ref Contrib.Data.Shared sharedData)
+    {
+        return Array.Empty<Vehicle>();
+    }
+
+    private static Vehicle? ToVehicle(ref Contrib.Data.Shared sharedData)
+    {
+        return new Vehicle
+        (
+            Id: 0, // TODO // TODO
+            ClassPerformanceIndex: -1, // TODO
+            RacingStatus: IRacingStatus.Unknown, // TODO
+            EngineType: EngineType.Unknown, // TODO
+            ControlType: ControlType.LocalPlayer, // TODO
+            Position: 0, // TODO
+            PositionClass: 0, // TODO
+            GapAhead: null, // TODO
+            GapBehind: null, // TODO
+            CompletedLaps: 0, // TODO
+            LapValid: LapValidState.Unknown, // TODO
+            CurrentLapTime: null, // TODO
+            PreviousLapTime: null, // TODO
+            BestLapTime: null, // TODO
+            BestSectors: null, // TODO
+            CurrentLapDistance: DistanceFraction.Of(IDistance.FromM(1), 0), // TODO
+            Location: new Vector3<IDistance> // TODO
+            (
+                X: IDistance.FromM(0),
+                Y: IDistance.FromM(0),
+                Z: IDistance.FromM(0)
+            ),
+            Orientation: null, // TODO
+            Speed: ISpeed.FromMPS(0), // TODO
+            CurrentDriver: new Driver // TODO
+            (
+                Name: ""
+            ),
+            Pit: new VehiclePit // TODO
+            (
+                StopsDone: 0,
+                MandatoryStopsDone: 0,
+                PitLanePhase: null,
+                PitLaneTime: null,
+                PitStallTime: null
+            ),
+            Penalties: Array.Empty<Penalty>(), // TODO
+            Flags: new VehicleFlags // TODO
+            (
+                Green: null,
+                Blue: null,
+                Yellow: null,
+                White: null,
+                Checkered: null,
+                Black: null,
+                BlackWhite: null
+            ),
+            Inputs: null // TODO
+        );
+    }
+
+    private static Vehicle? ToFocusedVehicle(ref Contrib.Data.Shared sharedData)
+    {
+        return new Vehicle
+        (
+            Id: 0, // TODO // TODO
+            ClassPerformanceIndex: -1, // TODO
+            RacingStatus: IRacingStatus.Unknown, // TODO
+            EngineType: EngineType.Unknown, // TODO
+            ControlType: ControlType.LocalPlayer, // TODO
+            Position: 0, // TODO
+            PositionClass: 0, // TODO
+            GapAhead: null, // TODO
+            GapBehind: null, // TODO
+            CompletedLaps: 0, // TODO
+            LapValid: LapValidState.Unknown, // TODO
+            CurrentLapTime: null, // TODO
+            PreviousLapTime : null, // TODO
+            BestLapTime : null, // TODO
+            BestSectors : null, // TODO
+            CurrentLapDistance: DistanceFraction.Of(IDistance.FromM(1), 0), // TODO
+            Location: new Vector3<IDistance> // TODO
+            (
+                X: IDistance.FromM(0),
+                Y: IDistance.FromM(0),
+                Z: IDistance.FromM(0)
+            ),
+            Orientation: null, // TODO
+            Speed: ISpeed.FromMPS(0), // TODO
+            CurrentDriver: new Driver // TODO
+            (
+                Name:  ""
+            ),
+            Pit: new VehiclePit // TODO
+            (
+                StopsDone: 0,
+                MandatoryStopsDone: 0,
+                PitLanePhase: null,
+                PitLaneTime: null,
+                PitStallTime: null
+            ),
+            Penalties: Array.Empty<Penalty>(), // TODO
+            Flags: new VehicleFlags // TODO
+            (
+                Green : null,
+                Blue : null,
+                Yellow : null,
+                White : null,
+                Checkered : null,
+                Black : null,
+                BlackWhite : null
+            ),
+            Inputs: null // TODO
+        );
+    }
+
+    private static Player? ToPlayer(ref Contrib.Data.Shared sharedData)
+    {
+        return new Player
+        (
+            RawInputs: new RawInputs // TODO
+            (
+                Throttle: 0,
+                Brake: 0,
+                Clutch: 0,
+                Steering: 0,
+                SteerWheelRange: IAngle.FromDeg(0)
+            ),
+            DrivingAids: new DrivingAids // TODO
+            (
+                Abs: null,
+                Tc: null,
+                Esp: null,
+                Countersteer: null,
+                Cornering: null
+            ),
+            VehicleSettings: new VehicleSettings // TODO
+            (
+                EngineMap: null,
+                EngineBrakeReduction: null
+            ),
+            VehicleDamage: new VehicleDamage // TODO
+            (
+                AerodynamicsPercent: 0,
+                EnginePercent: 0,
+                SuspensionPercent: 0,
+                TransmissionPercent: 0
+            ),
+            Tires: Array.Empty<Tire[]>(),
+            Fuel: new Fuel // TODO
+            (
+                Max: 0,
+                Left: 0,
+                PerLap: null
+            ),
+            Engine: new Engine // TODO
+            (
+                Speed: IAngularSpeed.FromRevPS(0),
+                UpshiftSpeed: IAngularSpeed.FromRevPS(0),
+                MaxSpeed: IAngularSpeed.FromRevPS(0)
+            ),
+            CgLocation: new Vector3<IDistance> // TODO
+            (
+                X: IDistance.FromM(0),
+                Y: IDistance.FromM(0),
+                Z: IDistance.FromM(0)
+            ),
+            Orientation: new Orientation // TODO
+            (
+                Yaw: IAngle.FromDeg(0),
+                Pitch: IAngle.FromDeg(0),
+                Roll: IAngle.FromDeg(0)
+            ),
+            LocalAcceleration: new Vector3<IAcceleration> // TODO
+            (
+                X: IAcceleration.FromMPS2(0),
+                Y: IAcceleration.FromMPS2(0),
+                Z: IAcceleration.FromMPS2(0)
+            ),
+            ClassBestLap: null,
+            ClassBestSectors: null, // TODO
+            PersonalBestSectors: null, // TODO
+            PersonalBestDelta: null, // TODO
+            Drs: null, // TODO
+            PushToPass: null, // TODO
+            PitStop: PlayerPitStop.None,
+            Warnings: new PlayerWarnings // TODO
+            (
+                IncidentPoints: null,
+                BlueFlagWarnings: null,
+                GiveBackPositions: 0
+            ),
+            OvertakeAllowed: null // TODO
+        );
     }
 }

--- a/src/RaceDirector/Pipeline/Games/R3E/Game.cs
+++ b/src/RaceDirector/Pipeline/Games/R3E/Game.cs
@@ -4,45 +4,44 @@ using System.Reactive.Linq;
 using System.Runtime.Versioning;
 using RaceDirector.Pipeline.Telemetry.V0;
 
-namespace RaceDirector.Pipeline.Games.R3E
+namespace RaceDirector.Pipeline.Games.R3E;
+
+[SupportedOSPlatform("windows")]
+public class Game : IGame
 {
-    [SupportedOSPlatform("windows")]
-    public class Game : IGame
+    public class Config
     {
-        public class Config
-        {
-            public TimeSpan PollingInterval { get; set; }
-        }
+        public TimeSpan PollingInterval { get; set; }
+    }
 
-        private Config _config;
+    private Config _config;
 
-        public string GameName => "R3E";
+    public string GameName => "R3E";
 
-        public string[] GameProcessNames => new[] { "RRRE64", "RRRE" };
+    public string[] GameProcessNames => new[] { "RRRE64", "RRRE" };
 
-        public Game(Config config)
-        {
-            _config = config;
-        }
+    public Game(Config config)
+    {
+        _config = config;
+    }
 
-        public IObservable<IGameTelemetry> CreateTelemetryObservable()
-        {
-            var mmReader = new MemoryMappedFileReader<Contrib.Data.Shared>(Contrib.Constant.SharedMemoryName);
-            var telemetryConverter = new TelemetryConverter();
-            return Observable.Interval(_config.PollingInterval)
-                .SelectMany(_ =>
+    public IObservable<IGameTelemetry> CreateTelemetryObservable()
+    {
+        var mmReader = new MemoryMappedFileReader<Contrib.Data.Shared>(Contrib.Constant.SharedMemoryName);
+        var telemetryConverter = new TelemetryConverter();
+        return Observable.Interval(_config.PollingInterval)
+            .SelectMany(_ =>
+            {
+                try
                 {
-                    try
-                    {
-                        var shared = mmReader.Read();
-                        var telemetry = telemetryConverter.Transform(ref shared);
-                        return Observable.Return(telemetry);
-                    }
-                    catch
-                    {
-                        return Observable.Empty<IGameTelemetry>();
-                    }
-                });
-        }
+                    var shared = mmReader.Read();
+                    var telemetry = telemetryConverter.Transform(ref shared);
+                    return Observable.Return(telemetry);
+                }
+                catch
+                {
+                    return Observable.Empty<IGameTelemetry>();
+                }
+            });
     }
 }

--- a/src/RaceDirector/Pipeline/Games/R3E/TelemetryConverter.cs
+++ b/src/RaceDirector/Pipeline/Games/R3E/TelemetryConverter.cs
@@ -5,800 +5,799 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace RaceDirector.Pipeline.Games.R3E
+namespace RaceDirector.Pipeline.Games.R3E;
+
+internal class TelemetryConverter
 {
-    internal class TelemetryConverter
+    private const uint MaxLights = 5;
+
+    // TODO what about passing the previous telemetry to the transform method?
+    private readonly StatefulAid<Aid> _statefulAbs = StatefulAid.Generic();
+    private readonly StatefulAid<TractionControl> _statefulTc = StatefulAid.Tc();
+    private readonly StatefulAid<Aid> _statefulEsp = StatefulAid.Generic();
+    private readonly StatefulAid<Aid> _statefulCountersteer = StatefulAid.Generic();
+    private readonly StatefulAid<Aid> _statefulCornering = StatefulAid.Generic();
+    private Interval<IPitWindowBoundary>? _pitWindowState;
+
+    internal GameTelemetry Transform(ref Contrib.Data.Shared sharedData)
     {
-        private const uint MaxLights = 5;
+        if (sharedData.VersionMajor != Contrib.Constant.VersionMajor)
+            throw new ArgumentException("Incompatible major version");
+        return new GameTelemetry(
+            GameState: ToGameState(ref sharedData),
+            UsingVR: sharedData.GameUsingVr > 0,
+            Event: ToEvent(ref sharedData),
+            Session: ToSession(ref sharedData),
+            Vehicles: ToVehicles(ref sharedData),
+            FocusedVehicle: ToFocusedVehicle(ref sharedData),
+            Player: ToPlayer(ref sharedData)
+        );
+    }
 
-        // TODO what about passing the previous telemetry to the transform method?
-        private readonly StatefulAid<Aid> _statefulAbs = StatefulAid.Generic();
-        private readonly StatefulAid<TractionControl> _statefulTc = StatefulAid.Tc();
-        private readonly StatefulAid<Aid> _statefulEsp = StatefulAid.Generic();
-        private readonly StatefulAid<Aid> _statefulCountersteer = StatefulAid.Generic();
-        private readonly StatefulAid<Aid> _statefulCornering = StatefulAid.Generic();
-        private Interval<IPitWindowBoundary>? _pitWindowState;
+    private static GameState ToGameState(ref Contrib.Data.Shared sharedData)
+    {
+        if (sharedData.GamePaused > 0)
+            return GameState.Paused;
+        if (sharedData.GameInMenus > 0)
+            return GameState.Menu;
+        if (sharedData.GameInReplay > 0)
+            return GameState.Replay;
+        return GameState.Driving; // TODO It should be in menu if no session
+    }
 
-        internal GameTelemetry Transform(ref Contrib.Data.Shared sharedData)
-        {
-            if (sharedData.VersionMajor != Contrib.Constant.VersionMajor)
-                throw new ArgumentException("Incompatible major version");
-            return new GameTelemetry(
-                GameState: ToGameState(ref sharedData),
-                UsingVR: sharedData.GameUsingVr > 0,
-                Event: ToEvent(ref sharedData),
-                Session: ToSession(ref sharedData),
-                Vehicles: ToVehicles(ref sharedData),
-                FocusedVehicle: ToFocusedVehicle(ref sharedData),
-                Player: ToPlayer(ref sharedData)
-            );
-        }
+    private Event? ToEvent(ref Contrib.Data.Shared sharedData)
+    {
+        var track = ToTrackLayout(ref sharedData);
+        if (track == null)
+            return null;
+        return new Event(
+            TrackLayout: track,
+            FuelRate: sharedData.FuelUseActive >= 0 ? sharedData.FuelUseActive : 0
+        );
+    }
 
-        private static GameState ToGameState(ref Contrib.Data.Shared sharedData)
-        {
-            if (sharedData.GamePaused > 0)
-                return GameState.Paused;
-            if (sharedData.GameInMenus > 0)
-                return GameState.Menu;
-            if (sharedData.GameInReplay > 0)
-                return GameState.Replay;
-            return GameState.Driving; // TODO It should be in menu if no session
-        }
+    private TrackLayout? ToTrackLayout(ref Contrib.Data.Shared sharedData)
+    {
+        if (sharedData.LayoutLength < 0)
+            return null;
+        var layoutLength = IDistance.FromM(sharedData.LayoutLength);
+        var sectors = ValuesPerSector(ref sharedData.SectorStartFactors,
+            i => DistanceFraction.FromTotal(layoutLength, i));
+        return new TrackLayout(
+            SectorsEnd: sectors
+        );
+    }
 
-        private Event? ToEvent(ref Contrib.Data.Shared sharedData)
-        {
-            var track = ToTrackLayout(ref sharedData);
-            if (track == null)
-                return null;
-            return new Event(
-                TrackLayout: track,
-                FuelRate: sharedData.FuelUseActive >= 0 ? sharedData.FuelUseActive : 0
-            );
-        }
+    private Session? ToSession(ref Contrib.Data.Shared sharedData)
+    {
+        var maybeSessionType = ToSessionType(ref sharedData);
+        var maybeSessionPhase = ToSessionPhase(ref sharedData);
+        if (maybeSessionType is null || maybeSessionPhase is null)
+            return null;
+        var maybeSessionLength = ToCurrentSessionLength(ref sharedData);
+        var sessionRequirements = ToSessionRequirements(ref sharedData);
+        var (elapsedTime, timeRemaining, waitTime) = RemainingTime(ref sharedData);
 
-        private TrackLayout? ToTrackLayout(ref Contrib.Data.Shared sharedData)
-        {
-            if (sharedData.LayoutLength < 0)
-                return null;
-            var layoutLength = IDistance.FromM(sharedData.LayoutLength);
-            var sectors = ValuesPerSector(ref sharedData.SectorStartFactors,
-                i => DistanceFraction.FromTotal(layoutLength, i));
-            return new TrackLayout(
-                SectorsEnd: sectors
-            );
-        }
-
-        private Session? ToSession(ref Contrib.Data.Shared sharedData)
-        {
-            var maybeSessionType = ToSessionType(ref sharedData);
-            var maybeSessionPhase = ToSessionPhase(ref sharedData);
-            if (maybeSessionType is null || maybeSessionPhase is null)
-                return null;
-            var maybeSessionLength = ToCurrentSessionLength(ref sharedData);
-            var sessionRequirements = ToSessionRequirements(ref sharedData);
-            var (elapsedTime, timeRemaining, waitTime) = RemainingTime(ref sharedData);
-
-            return new Session
+        return new Session
+        (
+            Type: maybeSessionType.Value,
+            Phase: maybeSessionPhase.Value,
+            Length: maybeSessionLength,
+            Requirements: sessionRequirements,
+            PitSpeedLimit: ISpeed.FromMPS(sharedData.SessionPitSpeedLimit),
+            PitLaneOpen: sharedData.PitWindowStatus > 0,
+            ElapsedTime: elapsedTime,
+            TimeRemaining: timeRemaining,
+            WaitTime: waitTime,
+            StartLights: ToStartLights(sharedData.StartLights),
+            BestLap: null, // TODO
+            BestSectors: null, // TODO
+            Flags: new SessionFlags // TODO
             (
-                Type: maybeSessionType.Value,
-                Phase: maybeSessionPhase.Value,
-                Length: maybeSessionLength,
-                Requirements: sessionRequirements,
-                PitSpeedLimit: ISpeed.FromMPS(sharedData.SessionPitSpeedLimit),
-                PitLaneOpen: sharedData.PitWindowStatus > 0,
-                ElapsedTime: elapsedTime,
-                TimeRemaining: timeRemaining,
-                WaitTime: waitTime,
-                StartLights: ToStartLights(sharedData.StartLights),
-                BestLap: null, // TODO
-                BestSectors: null, // TODO
-                Flags: new SessionFlags // TODO
-                (
-                    Track: TrackFlags.None,
-                    Sectors: Array.Empty<SectorFlags>(),
-                    Leader: LeaderFlags.None
-                )
-            );
-        }
+                Track: TrackFlags.None,
+                Sectors: Array.Empty<SectorFlags>(),
+                Leader: LeaderFlags.None
+            )
+        );
+    }
 
-        private static SessionType? ToSessionType(ref Contrib.Data.Shared sharedData) =>
-            sharedData.SessionType switch
-            {
-                Contrib.Constant.Session.Practice => SessionType.Practice,
-                Contrib.Constant.Session.Qualify => SessionType.Qualify,
-                Contrib.Constant.Session.Warmup => SessionType.Warmup,
-                Contrib.Constant.Session.Race => SessionType.Race,
-                _ => null
-            };
-
-        private static SessionPhase? ToSessionPhase(ref Contrib.Data.Shared sharedData) =>
-            sharedData.SessionPhase switch
-            {
-                Contrib.Constant.SessionPhase.Garage => SessionPhase.Garage,
-                Contrib.Constant.SessionPhase.Gridwalk => SessionPhase.GridWalk,
-                Contrib.Constant.SessionPhase.Formation => SessionPhase.Formation,
-                Contrib.Constant.SessionPhase.Countdown => SessionPhase.Countdown,
-                Contrib.Constant.SessionPhase.Green => SessionPhase.Started,
-                Contrib.Constant.SessionPhase.Checkered => SessionPhase.Over,
-                _ => null
-            };
-
-        private ISessionDuration? ToCurrentSessionLength(ref Contrib.Data.Shared sharedData) =>
-            ToSessionLength(sharedData.SessionTimeDuration, sharedData.NumberOfLaps);
-
-        private ISessionDuration? ToSessionLength(double secondsOrNegative, int lapsOrNegative)
+    private static SessionType? ToSessionType(ref Contrib.Data.Shared sharedData) =>
+        sharedData.SessionType switch
         {
-            if (lapsOrNegative >= 0)
-            {
-                if (secondsOrNegative >= 0)
-                    return new RaceDuration.TimePlusLapsDuration
-                    (
-                        Time: TimeSpan.FromSeconds(secondsOrNegative),
-                        ExtraLaps: Convert.ToUInt32(lapsOrNegative),
-                        EstimatedLaps: null // TODO
-                    );
-                else
-                    return new RaceDuration.LapsDuration
-                    (
-                        Laps: Convert.ToUInt32(lapsOrNegative),
-                        EstimatedTime: null // TODO
-                    );
-            }
-            else
-            {
-                if (secondsOrNegative >= 0)
-                    return new RaceDuration.TimeDuration
-                    (
-                        Time: TimeSpan.FromSeconds(secondsOrNegative),
-                        EstimatedLaps: null // TODO
-                    );
-                else
-                    return null;
-            }
-        }
-
-        private SessionRequirements ToSessionRequirements(ref Contrib.Data.Shared sharedData)
-        {
-            var currentPitWindow = ToPitWindow(ref sharedData);
-
-            // R3E removes the pit window when after it ends but we don't want that!
-            var pitWindowIsCorrect = sharedData.PitWindowStatus switch
-            {
-                Contrib.Constant.PitWindow.Unavailable => true,
-                Contrib.Constant.PitWindow.Disabled => true,
-                Contrib.Constant.PitWindow.Open => true,
-                _ => false // In other cases, the pit window might be wrong
-            };
-
-            // Keep the  previous pit window if null and unsure
-            if (currentPitWindow != null || pitWindowIsCorrect)
-                _pitWindowState = currentPitWindow;
-
-            // R3E only supports a single mandatory pit stop
-            var mandatoryPitStops = _pitWindowState is null ? 0u : 1u;
-
-            return new SessionRequirements
-            (
-                MandatoryPitStops: mandatoryPitStops,
-                MandatoryPitRequirements: 0, // TODO
-                PitWindow: _pitWindowState
-            );
-        }
-
-        private static (TimeSpan?, TimeSpan?, TimeSpan?) RemainingTime(ref Contrib.Data.Shared sharedData)
-        {
-            var timeRemaining = sharedData.SessionTimeRemaining;
-            var sessionTimeLength = sharedData.SessionTimeDuration;
-
-            if (sharedData.SessionPhase == Contrib.Constant.SessionPhase.Checkered)
-                // TODO infer elapsed time after checkered flag by storing GameSimulationTime at t0
-                return (null, TimeSpan.Zero, TimeSpan.FromSeconds(timeRemaining));
-
-            if (sessionTimeLength < 0 || timeRemaining < 0)
-                return (null, null, null);
-
-            return (TimeSpan.FromSeconds(sessionTimeLength - timeRemaining), TimeSpan.FromSeconds(timeRemaining), null);
-        }
-
-        private static Interval<IPitWindowBoundary>? ToPitWindow(ref Contrib.Data.Shared sharedData)
-        {
-            if (sharedData.PitWindowStart <= 0 || sharedData.PitWindowEnd <= 0)
-                return null;
-            else
-                return sharedData.SessionLengthFormat switch
-                {
-                    Contrib.Constant.SessionLengthFormat.LapBased =>
-                        new Interval<IPitWindowBoundary>
-                        (
-                            new RaceDuration.LapsDuration
-                            (
-                                Laps: Convert.ToUInt32(sharedData.PitWindowStart),
-                                EstimatedTime: null // TODO
-                            ),
-                            new RaceDuration.LapsDuration
-                            (
-                                Laps: Convert.ToUInt32(sharedData.PitWindowEnd),
-                                EstimatedTime: null // TODO
-                            )
-                        ),
-                    _ =>
-                        new Interval<IPitWindowBoundary>
-                        (
-                            new RaceDuration.TimeDuration
-                            (
-                                Time: TimeSpan.FromMinutes(Convert.ToDouble(sharedData.PitWindowStart)),
-                                EstimatedLaps: null // TODO
-                            ),
-                            new RaceDuration.TimeDuration
-                            (
-                                Time: TimeSpan.FromMinutes(Convert.ToDouble(sharedData.PitWindowEnd)),
-                                EstimatedLaps: null // TODO
-                            )
-                        ),
-                };
-        }
-
-        private static StartLights? ToStartLights(int startLights)
-        {
-            if (startLights < 0)
-                return null;
-            if (startLights > MaxLights)
-                return new StartLights
-                (
-                    Color: LightColor.Green,
-                    Lit: new BoundedValue<uint>(MaxLights, MaxLights)
-                );
-            return new StartLights
-            (
-                Color: LightColor.Red,
-                Lit: new BoundedValue<uint>((uint) startLights, MaxLights)
-            );
-        }
-
-        private Vehicle[] ToVehicles(ref Contrib.Data.Shared sharedData)
-        {
-            if (sharedData.NumCars <= 0)
-                return Array.Empty<Vehicle>();
-            var vehicles = new Vehicle[sharedData.NumCars];
-            for (var i = 0; i < sharedData.NumCars; i++)
-            {
-                vehicles[i] = ToVehicle(ref sharedData.DriverData[i], ref sharedData);
-            }
-
-            return vehicles;
-        }
-
-        private Vehicle ToVehicle(ref Contrib.Data.DriverData driverData, ref Contrib.Data.Shared sharedData)
-        {
-            return new Vehicle
-            (
-                Id: SafeUInt32(driverData.DriverInfo.SlotId),
-                ClassPerformanceIndex: driverData.DriverInfo.ClassPerformanceIndex,
-                RacingStatus: ToRacingStatus(driverData.FinishStatus),
-                EngineType: EngineType.Unknown, // TODO
-                ControlType: ControlType.Replay, // TODO
-                Position: 42, // TODO
-                PositionClass: SafeUInt32(driverData.PlaceClass),
-                GapAhead: TimeSpan.FromSeconds(driverData.TimeDeltaFront), // It can be negative!
-                GapBehind: TimeSpan.FromSeconds(driverData.TimeDeltaBehind), // It can be negative!
-                CompletedLaps: SafeUInt32(driverData.CompletedLaps),
-                LapValid: ToLapValid(driverData.CurrentLapValid),
-                CurrentLapTime: null, // TODO
-                PreviousLapTime: null, // TODO
-                BestLapTime: new LapTime
-                (
-                    Overall: TimeSpan.FromSeconds(42), // TODO
-                    Sectors: new Sectors
-                    (
-                        Individual: Array.Empty<TimeSpan>(), // TODO infer from cumulative
-                        Cumulative: ValuesPerSector(ref driverData.SectorTimeBestSelf, i => TimeSpan.FromSeconds(i))
-                    )
-                ),
-                BestSectors: null, // TODO
-                CurrentLapDistance: DistanceFraction.FromTotal(IDistance.FromM(sharedData.LayoutLength),
-                    IDistance.FromM(driverData.LapDistance)),
-                Location: Vector3(ref driverData.Position, i => IDistance.FromM(i)),
-                Orientation: null, // TODO
-                Speed: ISpeed.FromMPS(42), // TODO
-                CurrentDriver: new Driver
-                (
-                    Name: FromNullTerminatedByteArray(driverData.DriverInfo.Name)
-                ),
-                Pit: new VehiclePit
-                (
-                    StopsDone: SafeUInt32(driverData.NumPitstops),
-                    MandatoryStopsDone: ToMandatoryStopsDone(driverData.PitStopStatus),
-                    PitLanePhase: null, // TODO
-                    PitLaneTime: null, // TODO
-                    PitStallTime: null // TODO
-                ),
-                Penalties: Array.Empty<Penalty>(), // TODO
-                Flags: new VehicleFlags
-                (
-                    Green: null,
-                    Blue: null,
-                    Yellow: null,
-                    White: null,
-                    Checkered: null,
-                    Black: null,
-                    BlackWhite: null
-                ),
-                // IFocusedVehicle only
-                Inputs: null
-            );
-        }
-
-        private Vehicle? ToFocusedVehicle(ref Contrib.Data.Shared sharedData)
-        {
-            var currentSlotId = sharedData.VehicleInfo.SlotId;
-            if (currentSlotId < 0)
-                return null;
-            var driverDataIndex = Array.FindIndex(sharedData.DriverData, dd => dd.DriverInfo.SlotId == currentSlotId);
-            if (driverDataIndex < 0)
-                return null;
-            var currentDriverData = sharedData.DriverData[driverDataIndex];
-            var driverName = FromNullTerminatedByteArray(sharedData.PlayerName);
-
-            return new Vehicle
-            (
-                Id: SafeUInt32(sharedData.VehicleInfo.SlotId),
-                ClassPerformanceIndex: sharedData.VehicleInfo.ClassPerformanceIndex,
-                RacingStatus: ToRacingStatus(currentDriverData.FinishStatus), // TODO
-                EngineType: ToEngineType(ref sharedData),
-                ControlType: ToControlType(ref sharedData),
-                Position: 42, // TODO
-                PositionClass: SafeUInt32(sharedData.PositionClass),
-                GapAhead: null, // TODO
-                GapBehind: null, // TODO
-                CompletedLaps: SafeUInt32(currentDriverData.CompletedLaps),
-                LapValid: ToLapValid(sharedData.CurrentLapValid),
-                CurrentLapTime: new LapTime
-                (
-                    Overall: TimeSpan.FromSeconds(sharedData.LapTimeCurrentSelf),
-                    Sectors: new Sectors
-                    (
-                        Individual: Array.Empty<TimeSpan>(), // TODO infer from cumulative
-                        Cumulative: ValuesPerSector(ref sharedData.SectorTimesCurrentSelf, i => TimeSpan.FromSeconds(i))
-                    )
-                ),
-                PreviousLapTime: null, // TODO
-                BestLapTime: new LapTime
-                (
-                    Overall: TimeSpan.FromSeconds(sharedData.LapTimeBestSelf),
-                    Sectors: new Sectors
-                    (
-                        Individual: Array.Empty<TimeSpan>(), // TODO infer from cumulative
-                        Cumulative: ValuesPerSector(ref sharedData.SectorTimesBestSelf, i => TimeSpan.FromSeconds(i))
-                    )
-                ),
-                BestSectors: null, // TODO
-                CurrentLapDistance: DistanceFraction.Of(IDistance.FromM(sharedData.LapDistance),
-                    sharedData.LapDistanceFraction),
-                Location: Vector3(ref sharedData.CarCgLocation, i => IDistance.FromM(i)),
-                Orientation: ToOrientation(ref sharedData.CarOrientation, i => IAngle.FromRad(i)),
-                Speed: ISpeed.FromMPS(sharedData.CarSpeed),
-                CurrentDriver: new Driver
-                (
-                    Name: driverName
-                ),
-                Pit: new VehiclePit
-                (
-                    StopsDone: SafeUInt32(currentDriverData.NumPitstops),
-                    MandatoryStopsDone: ToMandatoryStopsDone(currentDriverData.PitStopStatus),
-                    PitLanePhase: ToPitLanePhase(ref sharedData),
-                    PitLaneTime: TimeSpan.FromSeconds(sharedData.PitTotalDuration),
-                    PitStallTime: TimeSpan.FromSeconds(sharedData.PitElapsedTime)
-                ),
-                Penalties: ToPenalties(sharedData.Penalties),
-                Flags: ToVehicleFlags(sharedData.Flags),
-                // IFocusedVehicle only
-                Inputs: new Inputs
-                (
-                    Throttle: sharedData.Throttle,
-                    Brake: sharedData.Brake,
-                    Clutch: sharedData.Clutch
-                )
-            );
-        }
-
-        private EngineType ToEngineType(ref Contrib.Data.Shared sharedData) =>
-            sharedData.VehicleInfo.EngineType switch
-            {
-                Contrib.Constant.EngineType.Combustion => EngineType.Combustion,
-                Contrib.Constant.EngineType.Electric => EngineType.Electric,
-                Contrib.Constant.EngineType.Hybrid => EngineType.Hybrid,
-                _ => EngineType.Unknown
-            };
-
-        private ControlType ToControlType(ref Contrib.Data.Shared sharedData) =>
-            sharedData.ControlType switch
-            {
-                Contrib.Constant.Control.Player => ControlType.LocalPlayer,
-                Contrib.Constant.Control.AI => ControlType.AI,
-                Contrib.Constant.Control.Remote => ControlType.RemotePlayer,
-                Contrib.Constant.Control.Replay => ControlType.Replay,
-                _ => ControlType.LocalPlayer // TODO
-            };
-
-        private LapValidState ToLapValid(int currentLapValid) => currentLapValid switch
-        {
-            0 => LapValidState.Invalid,
-            1 => LapValidState.Valid,
-            _ => LapValidState.Unknown
+            Contrib.Constant.Session.Practice => SessionType.Practice,
+            Contrib.Constant.Session.Qualify => SessionType.Qualify,
+            Contrib.Constant.Session.Warmup => SessionType.Warmup,
+            Contrib.Constant.Session.Race => SessionType.Race,
+            _ => null
         };
 
-        private PitLanePhase? ToPitLanePhase(ref Contrib.Data.Shared sharedData) =>
-            sharedData.PitState switch
-            {
-                2 => PitLanePhase.Entered,
-                3 => PitLanePhase.Stopped,
-                4 => PitLanePhase.Exiting,
-                _ => null
-            };
-
-        private uint ToMandatoryStopsDone(Contrib.Constant.PitStopStatus pitStopStatus) =>
-            (Contrib.Constant.PitStopStatus.Served == pitStopStatus) ? 1u : 0u;
-
-        private static Penalty[] ToPenalties(Contrib.Data.CutTrackPenalties cutTrackPenalties)
+    private static SessionPhase? ToSessionPhase(ref Contrib.Data.Shared sharedData) =>
+        sharedData.SessionPhase switch
         {
-            var penalties = new List<Penalty>();
-            if (cutTrackPenalties.DriveThrough > 0)
-                penalties.Add(new Penalty(PenaltyType.DriveThrough, PenaltyReason.Unknown));
-            if (cutTrackPenalties.StopAndGo > 0)
-                penalties.Add(new Penalty(PenaltyType.StopAndGo10, PenaltyReason.Unknown));
-            if (cutTrackPenalties.PitStop > 0)
-                penalties.Add(new Penalty(PenaltyType.PitStop, PenaltyReason.Unknown));
-            if (cutTrackPenalties.TimeDeduction > 0)
-                penalties.Add(new Penalty(PenaltyType.TimeDeduction, PenaltyReason.Unknown));
-            if (cutTrackPenalties.SlowDown > 0)
-                penalties.Add(new Penalty(PenaltyType.SlowDown, PenaltyReason.Unknown));
-            return penalties.ToArray();
+            Contrib.Constant.SessionPhase.Garage => SessionPhase.Garage,
+            Contrib.Constant.SessionPhase.Gridwalk => SessionPhase.GridWalk,
+            Contrib.Constant.SessionPhase.Formation => SessionPhase.Formation,
+            Contrib.Constant.SessionPhase.Countdown => SessionPhase.Countdown,
+            Contrib.Constant.SessionPhase.Green => SessionPhase.Started,
+            Contrib.Constant.SessionPhase.Checkered => SessionPhase.Over,
+            _ => null
+        };
+
+    private ISessionDuration? ToCurrentSessionLength(ref Contrib.Data.Shared sharedData) =>
+        ToSessionLength(sharedData.SessionTimeDuration, sharedData.NumberOfLaps);
+
+    private ISessionDuration? ToSessionLength(double secondsOrNegative, int lapsOrNegative)
+    {
+        if (lapsOrNegative >= 0)
+        {
+            if (secondsOrNegative >= 0)
+                return new RaceDuration.TimePlusLapsDuration
+                (
+                    Time: TimeSpan.FromSeconds(secondsOrNegative),
+                    ExtraLaps: Convert.ToUInt32(lapsOrNegative),
+                    EstimatedLaps: null // TODO
+                );
+            else
+                return new RaceDuration.LapsDuration
+                (
+                    Laps: Convert.ToUInt32(lapsOrNegative),
+                    EstimatedTime: null // TODO
+                );
         }
-
-        private static VehicleFlags ToVehicleFlags(Contrib.Data.Flags flags)
+        else
         {
-            // TODO return -1 or 0 depending on what state the game is on
-            // only black and checquered available during replay
-            // not sure when in menus
-            return new VehicleFlags
-            (
-                Green: flags.Green > 0 ? new GreenFlag(IVehicleFlags.GreenReason.RaceStart) : null,
-                Blue: flags.Blue > 0 ? new BlueFlag(IVehicleFlags.BlueReason.Unknown) : null,
-                Yellow: flags.Yellow > 0 ? new YellowFlag(IVehicleFlags.YellowReason.Unknown) : null,
-                White: flags.White > 0 ? new WhiteFlag(IVehicleFlags.WhiteReason.SlowCarAhead) : null,
-                Checkered: flags.Checkered > 0 ? new Flag() : null,
-                Black: flags.Black > 0 ? new Flag() : null,
-                BlackWhite: flags.BlackAndWhite switch
-                {
-                    -1 => null,
-                    0 => null,
-                    1 => new BlackWhiteFlag(IVehicleFlags.BlackWhiteReason.IgnoredBlueFlags),
-                    2 => new BlackWhiteFlag(IVehicleFlags.BlackWhiteReason.IgnoredBlueFlags),
-                    3 => new BlackWhiteFlag(IVehicleFlags.BlackWhiteReason.WrongWay),
-                    4 => new BlackWhiteFlag(IVehicleFlags.BlackWhiteReason.Cutting),
-                    _ => new BlackWhiteFlag(IVehicleFlags.BlackWhiteReason.Unknown),
-                }
-            );
-        }
-
-        private static IRacingStatus ToRacingStatus(Contrib.Constant.FinishStatus finishStatus) =>
-            finishStatus switch
-            {
-                Contrib.Constant.FinishStatus.None => IRacingStatus.Racing,
-                Contrib.Constant.FinishStatus.Finished => IRacingStatus.Finished,
-                Contrib.Constant.FinishStatus.DNF => IRacingStatus.DNF,
-                Contrib.Constant.FinishStatus.DNQ => IRacingStatus.DNQ,
-                Contrib.Constant.FinishStatus.DNS => IRacingStatus.DNS,
-                Contrib.Constant.FinishStatus.DQ => new IRacingStatus.DQ(IRacingStatus.DQReason.Unknown),
-                _ => IRacingStatus.Unknown,
-            };
-
-
-        private Player? ToPlayer(ref Contrib.Data.Shared sharedData)
-        {
-            // TODO some of this is present in replay/monitor
-            if (sharedData.VehicleInfo.UserId < 0)
+            if (secondsOrNegative >= 0)
+                return new RaceDuration.TimeDuration
+                (
+                    Time: TimeSpan.FromSeconds(secondsOrNegative),
+                    EstimatedLaps: null // TODO
+                );
+            else
                 return null;
-            return new Player
-            (
-                RawInputs: new RawInputs
-                (
-                    Throttle: sharedData.ThrottleRaw,
-                    Brake: sharedData.BrakeRaw,
-                    Clutch: sharedData.ClutchRaw,
-                    Steering: sharedData.SteerInputRaw,
-                    SteerWheelRange: IAngle.FromDeg(sharedData.SteerWheelRangeDegrees)
-                ),
-                DrivingAids: new DrivingAids
-                (
-                    Abs: _statefulAbs.Update(sharedData.AidSettings.Abs),
-                    Tc: _statefulTc.Update(sharedData.AidSettings.Tc),
-                    Esp: _statefulEsp.Update(sharedData.AidSettings.Esp),
-                    Countersteer: _statefulCountersteer.Update(sharedData.AidSettings.Countersteer),
-                    Cornering: _statefulCornering.Update(sharedData.AidSettings.Cornering)
-                ),
-                VehicleSettings: new VehicleSettings
-                (
-                    EngineMap: null, // TODO
-                    EngineBrakeReduction: null // TODO
-                ),
-                VehicleDamage: new VehicleDamage
-                (
-                    AerodynamicsPercent: sharedData.CarDamage.Aerodynamics,
-                    EnginePercent: sharedData.CarDamage.Engine,
-                    SuspensionPercent: sharedData.CarDamage.Suspension,
-                    TransmissionPercent: sharedData.CarDamage.Transmission
-                ),
-                Tires: ToTires(ref sharedData),
-                Fuel: new Fuel
-                (
-                    Max: sharedData.FuelCapacity,
-                    Left: sharedData.FuelLeft,
-                    PerLap: sharedData.FuelPerLap
-                ),
-                Engine: new Engine
-                (
-                    Speed: IAngularSpeed.FromRadPS(sharedData.EngineRps),
-                    UpshiftSpeed: IAngularSpeed.FromRadPS(sharedData.UpshiftRps),
-                    MaxSpeed: IAngularSpeed.FromRadPS(sharedData.MaxEngineRps)
-                ),
-                CgLocation: Vector3(ref sharedData.Player.Position, IDistance.FromM),
-                Orientation: new Orientation
-                (
-                    Yaw: IAngle.FromDeg(0.0), // TODO
-                    Pitch: IAngle.FromDeg(0.0), // TODO
-                    Roll: IAngle.FromDeg(0.0) // TODO
-                ),
-                LocalAcceleration: Vector3(ref sharedData.Player.LocalAcceleration, IAcceleration.FromMPS2),
-                ClassBestLap: null, // TODO
-                ClassBestSectors: new
-                    Sectors // TODO are these the best sectors of the class leader or the best class sectors???
+        }
+    }
+
+    private SessionRequirements ToSessionRequirements(ref Contrib.Data.Shared sharedData)
+    {
+        var currentPitWindow = ToPitWindow(ref sharedData);
+
+        // R3E removes the pit window when after it ends but we don't want that!
+        var pitWindowIsCorrect = sharedData.PitWindowStatus switch
+        {
+            Contrib.Constant.PitWindow.Unavailable => true,
+            Contrib.Constant.PitWindow.Disabled => true,
+            Contrib.Constant.PitWindow.Open => true,
+            _ => false // In other cases, the pit window might be wrong
+        };
+
+        // Keep the  previous pit window if null and unsure
+        if (currentPitWindow != null || pitWindowIsCorrect)
+            _pitWindowState = currentPitWindow;
+
+        // R3E only supports a single mandatory pit stop
+        var mandatoryPitStops = _pitWindowState is null ? 0u : 1u;
+
+        return new SessionRequirements
+        (
+            MandatoryPitStops: mandatoryPitStops,
+            MandatoryPitRequirements: 0, // TODO
+            PitWindow: _pitWindowState
+        );
+    }
+
+    private static (TimeSpan?, TimeSpan?, TimeSpan?) RemainingTime(ref Contrib.Data.Shared sharedData)
+    {
+        var timeRemaining = sharedData.SessionTimeRemaining;
+        var sessionTimeLength = sharedData.SessionTimeDuration;
+
+        if (sharedData.SessionPhase == Contrib.Constant.SessionPhase.Checkered)
+            // TODO infer elapsed time after checkered flag by storing GameSimulationTime at t0
+            return (null, TimeSpan.Zero, TimeSpan.FromSeconds(timeRemaining));
+
+        if (sessionTimeLength < 0 || timeRemaining < 0)
+            return (null, null, null);
+
+        return (TimeSpan.FromSeconds(sessionTimeLength - timeRemaining), TimeSpan.FromSeconds(timeRemaining), null);
+    }
+
+    private static Interval<IPitWindowBoundary>? ToPitWindow(ref Contrib.Data.Shared sharedData)
+    {
+        if (sharedData.PitWindowStart <= 0 || sharedData.PitWindowEnd <= 0)
+            return null;
+        else
+            return sharedData.SessionLengthFormat switch
+            {
+                Contrib.Constant.SessionLengthFormat.LapBased =>
+                    new Interval<IPitWindowBoundary>
                     (
-                        Individual: ValuesPerSector(ref sharedData.BestIndividualSectorTimeLeaderClass,
-                            i => TimeSpan.FromSeconds(i)),
-                        Cumulative: Array.Empty<TimeSpan>() // TODO
+                        new RaceDuration.LapsDuration
+                        (
+                            Laps: Convert.ToUInt32(sharedData.PitWindowStart),
+                            EstimatedTime: null // TODO
+                        ),
+                        new RaceDuration.LapsDuration
+                        (
+                            Laps: Convert.ToUInt32(sharedData.PitWindowEnd),
+                            EstimatedTime: null // TODO
+                        )
                     ),
-                PersonalBestSectors: new Sectors
+                _ =>
+                    new Interval<IPitWindowBoundary>
+                    (
+                        new RaceDuration.TimeDuration
+                        (
+                            Time: TimeSpan.FromMinutes(Convert.ToDouble(sharedData.PitWindowStart)),
+                            EstimatedLaps: null // TODO
+                        ),
+                        new RaceDuration.TimeDuration
+                        (
+                            Time: TimeSpan.FromMinutes(Convert.ToDouble(sharedData.PitWindowEnd)),
+                            EstimatedLaps: null // TODO
+                        )
+                    ),
+            };
+    }
+
+    private static StartLights? ToStartLights(int startLights)
+    {
+        if (startLights < 0)
+            return null;
+        if (startLights > MaxLights)
+            return new StartLights
+            (
+                Color: LightColor.Green,
+                Lit: new BoundedValue<uint>(MaxLights, MaxLights)
+            );
+        return new StartLights
+        (
+            Color: LightColor.Red,
+            Lit: new BoundedValue<uint>((uint) startLights, MaxLights)
+        );
+    }
+
+    private Vehicle[] ToVehicles(ref Contrib.Data.Shared sharedData)
+    {
+        if (sharedData.NumCars <= 0)
+            return Array.Empty<Vehicle>();
+        var vehicles = new Vehicle[sharedData.NumCars];
+        for (var i = 0; i < sharedData.NumCars; i++)
+        {
+            vehicles[i] = ToVehicle(ref sharedData.DriverData[i], ref sharedData);
+        }
+
+        return vehicles;
+    }
+
+    private Vehicle ToVehicle(ref Contrib.Data.DriverData driverData, ref Contrib.Data.Shared sharedData)
+    {
+        return new Vehicle
+        (
+            Id: SafeUInt32(driverData.DriverInfo.SlotId),
+            ClassPerformanceIndex: driverData.DriverInfo.ClassPerformanceIndex,
+            RacingStatus: ToRacingStatus(driverData.FinishStatus),
+            EngineType: EngineType.Unknown, // TODO
+            ControlType: ControlType.Replay, // TODO
+            Position: 42, // TODO
+            PositionClass: SafeUInt32(driverData.PlaceClass),
+            GapAhead: TimeSpan.FromSeconds(driverData.TimeDeltaFront), // It can be negative!
+            GapBehind: TimeSpan.FromSeconds(driverData.TimeDeltaBehind), // It can be negative!
+            CompletedLaps: SafeUInt32(driverData.CompletedLaps),
+            LapValid: ToLapValid(driverData.CurrentLapValid),
+            CurrentLapTime: null, // TODO
+            PreviousLapTime: null, // TODO
+            BestLapTime: new LapTime
+            (
+                Overall: TimeSpan.FromSeconds(42), // TODO
+                Sectors: new Sectors
                 (
-                    Individual: ValuesPerSector(ref sharedData.BestIndividualSectorTimeSelf,
+                    Individual: Array.Empty<TimeSpan>(), // TODO infer from cumulative
+                    Cumulative: ValuesPerSector(ref driverData.SectorTimeBestSelf, i => TimeSpan.FromSeconds(i))
+                )
+            ),
+            BestSectors: null, // TODO
+            CurrentLapDistance: DistanceFraction.FromTotal(IDistance.FromM(sharedData.LayoutLength),
+                IDistance.FromM(driverData.LapDistance)),
+            Location: Vector3(ref driverData.Position, i => IDistance.FromM(i)),
+            Orientation: null, // TODO
+            Speed: ISpeed.FromMPS(42), // TODO
+            CurrentDriver: new Driver
+            (
+                Name: FromNullTerminatedByteArray(driverData.DriverInfo.Name)
+            ),
+            Pit: new VehiclePit
+            (
+                StopsDone: SafeUInt32(driverData.NumPitstops),
+                MandatoryStopsDone: ToMandatoryStopsDone(driverData.PitStopStatus),
+                PitLanePhase: null, // TODO
+                PitLaneTime: null, // TODO
+                PitStallTime: null // TODO
+            ),
+            Penalties: Array.Empty<Penalty>(), // TODO
+            Flags: new VehicleFlags
+            (
+                Green: null,
+                Blue: null,
+                Yellow: null,
+                White: null,
+                Checkered: null,
+                Black: null,
+                BlackWhite: null
+            ),
+            // IFocusedVehicle only
+            Inputs: null
+        );
+    }
+
+    private Vehicle? ToFocusedVehicle(ref Contrib.Data.Shared sharedData)
+    {
+        var currentSlotId = sharedData.VehicleInfo.SlotId;
+        if (currentSlotId < 0)
+            return null;
+        var driverDataIndex = Array.FindIndex(sharedData.DriverData, dd => dd.DriverInfo.SlotId == currentSlotId);
+        if (driverDataIndex < 0)
+            return null;
+        var currentDriverData = sharedData.DriverData[driverDataIndex];
+        var driverName = FromNullTerminatedByteArray(sharedData.PlayerName);
+
+        return new Vehicle
+        (
+            Id: SafeUInt32(sharedData.VehicleInfo.SlotId),
+            ClassPerformanceIndex: sharedData.VehicleInfo.ClassPerformanceIndex,
+            RacingStatus: ToRacingStatus(currentDriverData.FinishStatus), // TODO
+            EngineType: ToEngineType(ref sharedData),
+            ControlType: ToControlType(ref sharedData),
+            Position: 42, // TODO
+            PositionClass: SafeUInt32(sharedData.PositionClass),
+            GapAhead: null, // TODO
+            GapBehind: null, // TODO
+            CompletedLaps: SafeUInt32(currentDriverData.CompletedLaps),
+            LapValid: ToLapValid(sharedData.CurrentLapValid),
+            CurrentLapTime: new LapTime
+            (
+                Overall: TimeSpan.FromSeconds(sharedData.LapTimeCurrentSelf),
+                Sectors: new Sectors
+                (
+                    Individual: Array.Empty<TimeSpan>(), // TODO infer from cumulative
+                    Cumulative: ValuesPerSector(ref sharedData.SectorTimesCurrentSelf, i => TimeSpan.FromSeconds(i))
+                )
+            ),
+            PreviousLapTime: null, // TODO
+            BestLapTime: new LapTime
+            (
+                Overall: TimeSpan.FromSeconds(sharedData.LapTimeBestSelf),
+                Sectors: new Sectors
+                (
+                    Individual: Array.Empty<TimeSpan>(), // TODO infer from cumulative
+                    Cumulative: ValuesPerSector(ref sharedData.SectorTimesBestSelf, i => TimeSpan.FromSeconds(i))
+                )
+            ),
+            BestSectors: null, // TODO
+            CurrentLapDistance: DistanceFraction.Of(IDistance.FromM(sharedData.LapDistance),
+                sharedData.LapDistanceFraction),
+            Location: Vector3(ref sharedData.CarCgLocation, i => IDistance.FromM(i)),
+            Orientation: ToOrientation(ref sharedData.CarOrientation, i => IAngle.FromRad(i)),
+            Speed: ISpeed.FromMPS(sharedData.CarSpeed),
+            CurrentDriver: new Driver
+            (
+                Name: driverName
+            ),
+            Pit: new VehiclePit
+            (
+                StopsDone: SafeUInt32(currentDriverData.NumPitstops),
+                MandatoryStopsDone: ToMandatoryStopsDone(currentDriverData.PitStopStatus),
+                PitLanePhase: ToPitLanePhase(ref sharedData),
+                PitLaneTime: TimeSpan.FromSeconds(sharedData.PitTotalDuration),
+                PitStallTime: TimeSpan.FromSeconds(sharedData.PitElapsedTime)
+            ),
+            Penalties: ToPenalties(sharedData.Penalties),
+            Flags: ToVehicleFlags(sharedData.Flags),
+            // IFocusedVehicle only
+            Inputs: new Inputs
+            (
+                Throttle: sharedData.Throttle,
+                Brake: sharedData.Brake,
+                Clutch: sharedData.Clutch
+            )
+        );
+    }
+
+    private EngineType ToEngineType(ref Contrib.Data.Shared sharedData) =>
+        sharedData.VehicleInfo.EngineType switch
+        {
+            Contrib.Constant.EngineType.Combustion => EngineType.Combustion,
+            Contrib.Constant.EngineType.Electric => EngineType.Electric,
+            Contrib.Constant.EngineType.Hybrid => EngineType.Hybrid,
+            _ => EngineType.Unknown
+        };
+
+    private ControlType ToControlType(ref Contrib.Data.Shared sharedData) =>
+        sharedData.ControlType switch
+        {
+            Contrib.Constant.Control.Player => ControlType.LocalPlayer,
+            Contrib.Constant.Control.AI => ControlType.AI,
+            Contrib.Constant.Control.Remote => ControlType.RemotePlayer,
+            Contrib.Constant.Control.Replay => ControlType.Replay,
+            _ => ControlType.LocalPlayer // TODO
+        };
+
+    private LapValidState ToLapValid(int currentLapValid) => currentLapValid switch
+    {
+        0 => LapValidState.Invalid,
+        1 => LapValidState.Valid,
+        _ => LapValidState.Unknown
+    };
+
+    private PitLanePhase? ToPitLanePhase(ref Contrib.Data.Shared sharedData) =>
+        sharedData.PitState switch
+        {
+            2 => PitLanePhase.Entered,
+            3 => PitLanePhase.Stopped,
+            4 => PitLanePhase.Exiting,
+            _ => null
+        };
+
+    private uint ToMandatoryStopsDone(Contrib.Constant.PitStopStatus pitStopStatus) =>
+        (Contrib.Constant.PitStopStatus.Served == pitStopStatus) ? 1u : 0u;
+
+    private static Penalty[] ToPenalties(Contrib.Data.CutTrackPenalties cutTrackPenalties)
+    {
+        var penalties = new List<Penalty>();
+        if (cutTrackPenalties.DriveThrough > 0)
+            penalties.Add(new Penalty(PenaltyType.DriveThrough, PenaltyReason.Unknown));
+        if (cutTrackPenalties.StopAndGo > 0)
+            penalties.Add(new Penalty(PenaltyType.StopAndGo10, PenaltyReason.Unknown));
+        if (cutTrackPenalties.PitStop > 0)
+            penalties.Add(new Penalty(PenaltyType.PitStop, PenaltyReason.Unknown));
+        if (cutTrackPenalties.TimeDeduction > 0)
+            penalties.Add(new Penalty(PenaltyType.TimeDeduction, PenaltyReason.Unknown));
+        if (cutTrackPenalties.SlowDown > 0)
+            penalties.Add(new Penalty(PenaltyType.SlowDown, PenaltyReason.Unknown));
+        return penalties.ToArray();
+    }
+
+    private static VehicleFlags ToVehicleFlags(Contrib.Data.Flags flags)
+    {
+        // TODO return -1 or 0 depending on what state the game is on
+        // only black and checquered available during replay
+        // not sure when in menus
+        return new VehicleFlags
+        (
+            Green: flags.Green > 0 ? new GreenFlag(IVehicleFlags.GreenReason.RaceStart) : null,
+            Blue: flags.Blue > 0 ? new BlueFlag(IVehicleFlags.BlueReason.Unknown) : null,
+            Yellow: flags.Yellow > 0 ? new YellowFlag(IVehicleFlags.YellowReason.Unknown) : null,
+            White: flags.White > 0 ? new WhiteFlag(IVehicleFlags.WhiteReason.SlowCarAhead) : null,
+            Checkered: flags.Checkered > 0 ? new Flag() : null,
+            Black: flags.Black > 0 ? new Flag() : null,
+            BlackWhite: flags.BlackAndWhite switch
+            {
+                -1 => null,
+                0 => null,
+                1 => new BlackWhiteFlag(IVehicleFlags.BlackWhiteReason.IgnoredBlueFlags),
+                2 => new BlackWhiteFlag(IVehicleFlags.BlackWhiteReason.IgnoredBlueFlags),
+                3 => new BlackWhiteFlag(IVehicleFlags.BlackWhiteReason.WrongWay),
+                4 => new BlackWhiteFlag(IVehicleFlags.BlackWhiteReason.Cutting),
+                _ => new BlackWhiteFlag(IVehicleFlags.BlackWhiteReason.Unknown),
+            }
+        );
+    }
+
+    private static IRacingStatus ToRacingStatus(Contrib.Constant.FinishStatus finishStatus) =>
+        finishStatus switch
+        {
+            Contrib.Constant.FinishStatus.None => IRacingStatus.Racing,
+            Contrib.Constant.FinishStatus.Finished => IRacingStatus.Finished,
+            Contrib.Constant.FinishStatus.DNF => IRacingStatus.DNF,
+            Contrib.Constant.FinishStatus.DNQ => IRacingStatus.DNQ,
+            Contrib.Constant.FinishStatus.DNS => IRacingStatus.DNS,
+            Contrib.Constant.FinishStatus.DQ => new IRacingStatus.DQ(IRacingStatus.DQReason.Unknown),
+            _ => IRacingStatus.Unknown,
+        };
+
+
+    private Player? ToPlayer(ref Contrib.Data.Shared sharedData)
+    {
+        // TODO some of this is present in replay/monitor
+        if (sharedData.VehicleInfo.UserId < 0)
+            return null;
+        return new Player
+        (
+            RawInputs: new RawInputs
+            (
+                Throttle: sharedData.ThrottleRaw,
+                Brake: sharedData.BrakeRaw,
+                Clutch: sharedData.ClutchRaw,
+                Steering: sharedData.SteerInputRaw,
+                SteerWheelRange: IAngle.FromDeg(sharedData.SteerWheelRangeDegrees)
+            ),
+            DrivingAids: new DrivingAids
+            (
+                Abs: _statefulAbs.Update(sharedData.AidSettings.Abs),
+                Tc: _statefulTc.Update(sharedData.AidSettings.Tc),
+                Esp: _statefulEsp.Update(sharedData.AidSettings.Esp),
+                Countersteer: _statefulCountersteer.Update(sharedData.AidSettings.Countersteer),
+                Cornering: _statefulCornering.Update(sharedData.AidSettings.Cornering)
+            ),
+            VehicleSettings: new VehicleSettings
+            (
+                EngineMap: null, // TODO
+                EngineBrakeReduction: null // TODO
+            ),
+            VehicleDamage: new VehicleDamage
+            (
+                AerodynamicsPercent: sharedData.CarDamage.Aerodynamics,
+                EnginePercent: sharedData.CarDamage.Engine,
+                SuspensionPercent: sharedData.CarDamage.Suspension,
+                TransmissionPercent: sharedData.CarDamage.Transmission
+            ),
+            Tires: ToTires(ref sharedData),
+            Fuel: new Fuel
+            (
+                Max: sharedData.FuelCapacity,
+                Left: sharedData.FuelLeft,
+                PerLap: sharedData.FuelPerLap
+            ),
+            Engine: new Engine
+            (
+                Speed: IAngularSpeed.FromRadPS(sharedData.EngineRps),
+                UpshiftSpeed: IAngularSpeed.FromRadPS(sharedData.UpshiftRps),
+                MaxSpeed: IAngularSpeed.FromRadPS(sharedData.MaxEngineRps)
+            ),
+            CgLocation: Vector3(ref sharedData.Player.Position, IDistance.FromM),
+            Orientation: new Orientation
+            (
+                Yaw: IAngle.FromDeg(0.0), // TODO
+                Pitch: IAngle.FromDeg(0.0), // TODO
+                Roll: IAngle.FromDeg(0.0) // TODO
+            ),
+            LocalAcceleration: Vector3(ref sharedData.Player.LocalAcceleration, IAcceleration.FromMPS2),
+            ClassBestLap: null, // TODO
+            ClassBestSectors: new
+                Sectors // TODO are these the best sectors of the class leader or the best class sectors???
+                (
+                    Individual: ValuesPerSector(ref sharedData.BestIndividualSectorTimeLeaderClass,
                         i => TimeSpan.FromSeconds(i)),
                     Cumulative: Array.Empty<TimeSpan>() // TODO
                 ),
-                PersonalBestDelta: TimeSpan.FromSeconds(sharedData.TimeDeltaBestSelf),
-                Drs: ToDrs(ref sharedData),
-                PushToPass: ToPtp(ref sharedData),
-                PitStop: ToPlayerPitStop(ref sharedData),
-                Warnings: new PlayerWarnings
-                (
-                    IncidentPoints: null,
-                    BlueFlagWarnings: ToBlueFlagWarnings(sharedData.Flags.BlackAndWhite),
-                    GiveBackPositions: PositiveOrZero(sharedData.Flags.YellowPositionsGained)
-                ),
-                OvertakeAllowed: NullableBoolean(sharedData.Flags.YellowOvertake)
-            );
-        }
+            PersonalBestSectors: new Sectors
+            (
+                Individual: ValuesPerSector(ref sharedData.BestIndividualSectorTimeSelf,
+                    i => TimeSpan.FromSeconds(i)),
+                Cumulative: Array.Empty<TimeSpan>() // TODO
+            ),
+            PersonalBestDelta: TimeSpan.FromSeconds(sharedData.TimeDeltaBestSelf),
+            Drs: ToDrs(ref sharedData),
+            PushToPass: ToPtp(ref sharedData),
+            PitStop: ToPlayerPitStop(ref sharedData),
+            Warnings: new PlayerWarnings
+            (
+                IncidentPoints: null,
+                BlueFlagWarnings: ToBlueFlagWarnings(sharedData.Flags.BlackAndWhite),
+                GiveBackPositions: PositiveOrZero(sharedData.Flags.YellowPositionsGained)
+            ),
+            OvertakeAllowed: NullableBoolean(sharedData.Flags.YellowOvertake)
+        );
+    }
 
-        private static PlayerPitStop ToPlayerPitStop(ref Contrib.Data.Shared sharedData)
-        {
-            var playerPitStop = PlayerPitStop.None;
-            if (sharedData.PitState == 1)
-                playerPitStop |= PlayerPitStop.Requested;
-            foreach (var (pitActionFlag, playerPitStopFlag) in PitActionFlags)
-                if ((sharedData.PitAction & pitActionFlag) != 0)
-                    playerPitStop |= playerPitStopFlag;
-            return playerPitStop;
-        }
+    private static PlayerPitStop ToPlayerPitStop(ref Contrib.Data.Shared sharedData)
+    {
+        var playerPitStop = PlayerPitStop.None;
+        if (sharedData.PitState == 1)
+            playerPitStop |= PlayerPitStop.Requested;
+        foreach (var (pitActionFlag, playerPitStopFlag) in PitActionFlags)
+            if ((sharedData.PitAction & pitActionFlag) != 0)
+                playerPitStop |= playerPitStopFlag;
+        return playerPitStop;
+    }
 
-        private static readonly (int, PlayerPitStop)[] PitActionFlags =
+    private static readonly (int, PlayerPitStop)[] PitActionFlags =
+    {
+        (1, PlayerPitStop.Preparing),
+        (2, PlayerPitStop.ServingPenalty),
+        (4, PlayerPitStop.DriverChange),
+        (8, PlayerPitStop.Refuelling),
+        (16, PlayerPitStop.ChangeFrontTires),
+        (32, PlayerPitStop.ChangeRearTires),
+        (64, PlayerPitStop.RepairBody),
+        (128, PlayerPitStop.RepairFrontWing),
+        (256, PlayerPitStop.RepairRearWing),
+        (512, PlayerPitStop.RepairSuspension)
+    };
+
+    private static Orientation ToOrientation<T>(ref Contrib.Data.Orientation<T> value, Func<T, IAngle> f) =>
+        new(Yaw: f(value.Yaw), Pitch: f(value.Pitch), Roll: f(value.Roll));
+
+    private ActivationToggled? ToDrs(ref Contrib.Data.Shared sharedData)
+    {
+        var drs = sharedData.Drs;
+        if (drs.Equipped <= 0)
+            return null;
+        return new ActivationToggled
+        (
+            Available: drs.Available > 0,
+            Engaged: drs.Engaged > 0,
+            ActivationsLeft: new BoundedValue<uint>(
+                Value: SafeUInt32(drs.NumActivationsLeft),
+                Total: SafeUInt32(sharedData.DrsNumActivationsTotal)
+            )
+        );
+    }
+
+    private static WaitTimeToggled? ToPtp(ref Contrib.Data.Shared sharedData)
+    {
+        var ptp = sharedData.PushToPass;
+        if (ptp.Available < 0)
+            return null;
+        return new WaitTimeToggled
+        (
+            Available: ptp.Available > 0,
+            Engaged: ptp.Engaged > 0,
+            ActivationsLeft: new BoundedValue<uint>
+            (
+                Value: SafeUInt32(ptp.AmountLeft),
+                Total: SafeUInt32(sharedData.PtpNumActivationsTotal)
+            ),
+            EngagedTimeLeft: TimeSpan.FromSeconds(ptp.EngagedTimeLeft),
+            WaitTimeLeft: TimeSpan.FromSeconds(ptp.WaitTimeLeft)
+        );
+    }
+
+    private static Tire[][] ToTires(ref Contrib.Data.Shared sharedData)
+    {
+        return new[]
         {
-            (1, PlayerPitStop.Preparing),
-            (2, PlayerPitStop.ServingPenalty),
-            (4, PlayerPitStop.DriverChange),
-            (8, PlayerPitStop.Refuelling),
-            (16, PlayerPitStop.ChangeFrontTires),
-            (32, PlayerPitStop.ChangeRearTires),
-            (64, PlayerPitStop.RepairBody),
-            (128, PlayerPitStop.RepairFrontWing),
-            (256, PlayerPitStop.RepairRearWing),
-            (512, PlayerPitStop.RepairSuspension)
+            new[]
+            {
+                ToTire(ref sharedData, new ITireExtractor.FrontLeft()),
+                ToTire(ref sharedData, new ITireExtractor.FrontRight())
+            },
+            new[]
+            {
+                ToTire(ref sharedData, new ITireExtractor.RearLeft()),
+                ToTire(ref sharedData, new ITireExtractor.RearRight())
+            }
         };
+    }
 
-        private static Orientation ToOrientation<T>(ref Contrib.Data.Orientation<T> value, Func<T, IAngle> f) =>
-            new(Yaw: f(value.Yaw), Pitch: f(value.Pitch), Roll: f(value.Roll));
-
-        private ActivationToggled? ToDrs(ref Contrib.Data.Shared sharedData)
-        {
-            var drs = sharedData.Drs;
-            if (drs.Equipped <= 0)
-                return null;
-            return new ActivationToggled
+    private static Tire ToTire(ref Contrib.Data.Shared sharedData, ITireExtractor extract)
+    {
+        var tireTemps = extract.CurrentTire(ref sharedData.TireTemp);
+        var brakeTemps = extract.CurrentTire(ref sharedData.BrakeTemp);
+        return new Tire(
+            Dirt: extract.CurrentTire(ref sharedData.TireDirt),
+            Grip: extract.CurrentTire(ref sharedData.TireGrip),
+            Wear: extract.CurrentTire(ref sharedData.TireWear),
+            Temperatures: new TemperaturesMatrix
             (
-                Available: drs.Available > 0,
-                Engaged: drs.Engaged > 0,
-                ActivationsLeft: new BoundedValue<uint>(
-                    Value: SafeUInt32(drs.NumActivationsLeft),
-                    Total: SafeUInt32(sharedData.DrsNumActivationsTotal)
-                )
-            );
-        }
-
-        private static WaitTimeToggled? ToPtp(ref Contrib.Data.Shared sharedData)
-        {
-            var ptp = sharedData.PushToPass;
-            if (ptp.Available < 0)
-                return null;
-            return new WaitTimeToggled
-            (
-                Available: ptp.Available > 0,
-                Engaged: ptp.Engaged > 0,
-                ActivationsLeft: new BoundedValue<uint>
-                (
-                    Value: SafeUInt32(ptp.AmountLeft),
-                    Total: SafeUInt32(sharedData.PtpNumActivationsTotal)
-                ),
-                EngagedTimeLeft: TimeSpan.FromSeconds(ptp.EngagedTimeLeft),
-                WaitTimeLeft: TimeSpan.FromSeconds(ptp.WaitTimeLeft)
-            );
-        }
-
-        private static Tire[][] ToTires(ref Contrib.Data.Shared sharedData)
-        {
-            return new[]
-            {
-                new[]
+                CurrentTemperatures: new[]
                 {
-                    ToTire(ref sharedData, new ITireExtractor.FrontLeft()),
-                    ToTire(ref sharedData, new ITireExtractor.FrontRight())
-                },
-                new[]
-                {
-                    ToTire(ref sharedData, new ITireExtractor.RearLeft()),
-                    ToTire(ref sharedData, new ITireExtractor.RearRight())
-                }
-            };
-        }
-
-        private static Tire ToTire(ref Contrib.Data.Shared sharedData, ITireExtractor extract)
-        {
-            var tireTemps = extract.CurrentTire(ref sharedData.TireTemp);
-            var brakeTemps = extract.CurrentTire(ref sharedData.BrakeTemp);
-            return new Tire(
-                Dirt: extract.CurrentTire(ref sharedData.TireDirt),
-                Grip: extract.CurrentTire(ref sharedData.TireGrip),
-                Wear: extract.CurrentTire(ref sharedData.TireWear),
-                Temperatures: new TemperaturesMatrix
-                (
-                    CurrentTemperatures: new[]
+                    new[]
                     {
-                        new[]
-                        {
-                            ITemperature.FromC(tireTemps.CurrentTemp.Left),
-                            ITemperature.FromC(tireTemps.CurrentTemp.Center),
-                            ITemperature.FromC(tireTemps.CurrentTemp.Right)
-                        }
-                    },
-                    OptimalTemperature: ITemperature.FromC(tireTemps.OptimalTemp),
-                    ColdTemperature: ITemperature.FromC(tireTemps.ColdTemp),
-                    HotTemperature: ITemperature.FromC(tireTemps.HotTemp)
-                ),
-                BrakeTemperatures: new TemperaturesSingle
-                (
-                    CurrentTemperature: ITemperature.FromC(brakeTemps.CurrentTemp),
-                    OptimalTemperature: ITemperature.FromC(brakeTemps.OptimalTemp),
-                    ColdTemperature: ITemperature.FromC(brakeTemps.ColdTemp),
-                    HotTemperature: ITemperature.FromC(brakeTemps.HotTemp)
-                )
-            );
-        }
-
-        private interface ITireExtractor
-        {
-            T CurrentTire<T>(ref Contrib.Data.TireData<T> outer);
-
-            class FrontLeft : ITireExtractor
-            {
-                T ITireExtractor.CurrentTire<T>(ref Contrib.Data.TireData<T> outer) => outer.FrontLeft;
-            }
-
-            class FrontRight : ITireExtractor
-            {
-                T ITireExtractor.CurrentTire<T>(ref Contrib.Data.TireData<T> outer) => outer.FrontRight;
-            }
-
-            class RearLeft : ITireExtractor
-            {
-                T ITireExtractor.CurrentTire<T>(ref Contrib.Data.TireData<T> outer) => outer.RearLeft;
-            }
-
-            class RearRight : ITireExtractor
-            {
-                T ITireExtractor.CurrentTire<T>(ref Contrib.Data.TireData<T> outer) => outer.RearRight;
-            }
-        }
-
-        private static IBoundedValue<uint> ToBlueFlagWarnings(int blackAndWhite)
-        {
-            uint blueWarnings = blackAndWhite switch
-            {
-                1 => 1,
-                2 => 2,
-                _ => 0
-            };
-            return new BoundedValue<uint>(blueWarnings, 2);
-        }
-
-        private static uint PositiveOrZero(int value) => value > 0 ? (uint) value : 0;
-
-        private static string FromNullTerminatedByteArray(byte[] nullTerminated)
-        {
-            var nullIndex = Array.IndexOf<byte>(nullTerminated, 0);
-            if (nullIndex < 0)
-                nullIndex = nullTerminated.Length;
-            return Encoding.UTF8.GetString(nullTerminated, 0, nullIndex);
-        }
-
-        private static Vector3<TO> Vector3<TI, TO>(ref Contrib.Data.Vector3<TI> value, Func<TI, TO> f) =>
-            new(X: f(value.X), Y: f(value.Y), Z: f(value.Z));
-
-        private static TO[] ValuesPerSector<TI, TO>(ref Contrib.Data.Sectors<TI> value, Func<TI, TO> f) =>
-            new[] {f(value.Sector1), f(value.Sector2), f(value.Sector3)};
-
-        private static TO[] ValuesPerSector<TI, TO>(ref Contrib.Data.SectorStarts<TI> value, Func<TI, TO> f) =>
-            new[] {f(value.Sector1), f(value.Sector2), f(value.Sector3)};
-
-        private static uint SafeUInt32(int i, uint defaultValue = 0)
-        {
-            return i < 0 ? defaultValue : (uint) i;
-        }
-
-        private static bool? NullableBoolean(int i)
-        {
-            return i switch
-            {
-                < 0 => null,
-                > 0 => true,
-                _ => false
-            };
-        }
+                        ITemperature.FromC(tireTemps.CurrentTemp.Left),
+                        ITemperature.FromC(tireTemps.CurrentTemp.Center),
+                        ITemperature.FromC(tireTemps.CurrentTemp.Right)
+                    }
+                },
+                OptimalTemperature: ITemperature.FromC(tireTemps.OptimalTemp),
+                ColdTemperature: ITemperature.FromC(tireTemps.ColdTemp),
+                HotTemperature: ITemperature.FromC(tireTemps.HotTemp)
+            ),
+            BrakeTemperatures: new TemperaturesSingle
+            (
+                CurrentTemperature: ITemperature.FromC(brakeTemps.CurrentTemp),
+                OptimalTemperature: ITemperature.FromC(brakeTemps.OptimalTemp),
+                ColdTemperature: ITemperature.FromC(brakeTemps.ColdTemp),
+                HotTemperature: ITemperature.FromC(brakeTemps.HotTemp)
+            )
+        );
     }
 
-    /// <summary>
-    /// Keeps track of the previous aid value for when its activated value hides it.
-    /// </summary>
-    public class StatefulAid<T> where T : Aid
+    private interface ITireExtractor
     {
-        private T? _current;
-        private readonly Func<uint, T> _constructor;
+        T CurrentTire<T>(ref Contrib.Data.TireData<T> outer);
 
-        public StatefulAid(Func<uint, T> constructor)
+        class FrontLeft : ITireExtractor
         {
-            _constructor = constructor;
+            T ITireExtractor.CurrentTire<T>(ref Contrib.Data.TireData<T> outer) => outer.FrontLeft;
         }
 
-        public T? Update(int newLevel)
+        class FrontRight : ITireExtractor
         {
-            switch (newLevel)
-            {
-                case < 0:
-                    _current = null;
-                    break;
-                case 5:
-                    if (_current != null)
-                        _current = _current with {Active = true};
-                    break;
-                default:
-                    _current = _constructor((uint) newLevel);
-                    break;
-            }
+            T ITireExtractor.CurrentTire<T>(ref Contrib.Data.TireData<T> outer) => outer.FrontRight;
+        }
 
-            return _current;
+        class RearLeft : ITireExtractor
+        {
+            T ITireExtractor.CurrentTire<T>(ref Contrib.Data.TireData<T> outer) => outer.RearLeft;
+        }
+
+        class RearRight : ITireExtractor
+        {
+            T ITireExtractor.CurrentTire<T>(ref Contrib.Data.TireData<T> outer) => outer.RearRight;
         }
     }
 
-    public static class StatefulAid
+    private static IBoundedValue<uint> ToBlueFlagWarnings(int blackAndWhite)
     {
-        public static StatefulAid<Aid> Generic() => new(level => new Aid(level, false));
-
-        public static StatefulAid<TractionControl> Tc() => new(level => new TractionControl(level, false, null));
+        uint blueWarnings = blackAndWhite switch
+        {
+            1 => 1,
+            2 => 2,
+            _ => 0
+        };
+        return new BoundedValue<uint>(blueWarnings, 2);
     }
+
+    private static uint PositiveOrZero(int value) => value > 0 ? (uint) value : 0;
+
+    private static string FromNullTerminatedByteArray(byte[] nullTerminated)
+    {
+        var nullIndex = Array.IndexOf<byte>(nullTerminated, 0);
+        if (nullIndex < 0)
+            nullIndex = nullTerminated.Length;
+        return Encoding.UTF8.GetString(nullTerminated, 0, nullIndex);
+    }
+
+    private static Vector3<TO> Vector3<TI, TO>(ref Contrib.Data.Vector3<TI> value, Func<TI, TO> f) =>
+        new(X: f(value.X), Y: f(value.Y), Z: f(value.Z));
+
+    private static TO[] ValuesPerSector<TI, TO>(ref Contrib.Data.Sectors<TI> value, Func<TI, TO> f) =>
+        new[] {f(value.Sector1), f(value.Sector2), f(value.Sector3)};
+
+    private static TO[] ValuesPerSector<TI, TO>(ref Contrib.Data.SectorStarts<TI> value, Func<TI, TO> f) =>
+        new[] {f(value.Sector1), f(value.Sector2), f(value.Sector3)};
+
+    private static uint SafeUInt32(int i, uint defaultValue = 0)
+    {
+        return i < 0 ? defaultValue : (uint) i;
+    }
+
+    private static bool? NullableBoolean(int i)
+    {
+        return i switch
+        {
+            < 0 => null,
+            > 0 => true,
+            _ => false
+        };
+    }
+}
+
+/// <summary>
+/// Keeps track of the previous aid value for when its activated value hides it.
+/// </summary>
+public class StatefulAid<T> where T : Aid
+{
+    private T? _current;
+    private readonly Func<uint, T> _constructor;
+
+    public StatefulAid(Func<uint, T> constructor)
+    {
+        _constructor = constructor;
+    }
+
+    public T? Update(int newLevel)
+    {
+        switch (newLevel)
+        {
+            case < 0:
+                _current = null;
+                break;
+            case 5:
+                if (_current != null)
+                    _current = _current with {Active = true};
+                break;
+            default:
+                _current = _constructor((uint) newLevel);
+                break;
+        }
+
+        return _current;
+    }
+}
+
+public static class StatefulAid
+{
+    public static StatefulAid<Aid> Generic() => new(level => new Aid(level, false));
+
+    public static StatefulAid<TractionControl> Tc() => new(level => new TractionControl(level, false, null));
 }

--- a/src/RaceDirector/Pipeline/PipelineBuilder.cs
+++ b/src/RaceDirector/Pipeline/PipelineBuilder.cs
@@ -2,60 +2,59 @@
 using System.Collections.Generic;
 using System.Reflection;
 
-namespace RaceDirector.Pipeline
-{
-    /// <remarks>
-    /// Dirty use of reflection and dynamic types. At least it's isolated here.
-    /// </remarks>
-    public static class PipelineBuilder
-    {
-        /// <summary>
-        /// Linking observable and observer node properties based on their types.
-        /// </summary>
-        /// <param name="nodes">Nodes to inspect.</param>
-        public static void LinkNodes(IEnumerable<INode> nodes)
-        {
-            ForEachProperty(typeof(IObservable<>), nodes, (observableType, observable) =>
-            {
-                ForEachProperty(typeof(IObserver<>), nodes, (observerType, observer) =>
-                {
-                    var observableGenericType = observableType.GenericTypeArguments[0];
-                    var observerGenericType = observerType.GenericTypeArguments[0];
-                    if (observerGenericType.IsAssignableFrom(observableGenericType))
-                    {
-                        observableType.InvokeMember(nameof(IObservable<object>.Subscribe), BindingFlags.InvokeMethod, null, observable, new[] { observer });
-                    }
-                });
-            });
-        }
+namespace RaceDirector.Pipeline;
 
-        private static void ForEachProperty(Type genericTypeDefinition, IEnumerable<object> objects, Action<Type, dynamic> action)
+/// <remarks>
+/// Dirty use of reflection and dynamic types. At least it's isolated here.
+/// </remarks>
+public static class PipelineBuilder
+{
+    /// <summary>
+    /// Linking observable and observer node properties based on their types.
+    /// </summary>
+    /// <param name="nodes">Nodes to inspect.</param>
+    public static void LinkNodes(IEnumerable<INode> nodes)
+    {
+        ForEachProperty(typeof(IObservable<>), nodes, (observableType, observable) =>
         {
-            foreach (var o in objects)
+            ForEachProperty(typeof(IObserver<>), nodes, (observerType, observer) =>
             {
-                foreach (var property in o.GetType().GetProperties())
+                var observableGenericType = observableType.GenericTypeArguments[0];
+                var observerGenericType = observerType.GenericTypeArguments[0];
+                if (observerGenericType.IsAssignableFrom(observableGenericType))
                 {
-                    var implementedGenericType = property.PropertyType.Implements(genericTypeDefinition);
-                    if (implementedGenericType is not null)
-                    {
-                        dynamic? propertyValue = property.GetValue(o);
-                        if (propertyValue is not null)
-                            action(implementedGenericType, propertyValue);
-                    }
+                    observableType.InvokeMember(nameof(IObservable<object>.Subscribe), BindingFlags.InvokeMethod, null, observable, new[] { observer });
+                }
+            });
+        });
+    }
+
+    private static void ForEachProperty(Type genericTypeDefinition, IEnumerable<object> objects, Action<Type, dynamic> action)
+    {
+        foreach (var o in objects)
+        {
+            foreach (var property in o.GetType().GetProperties())
+            {
+                var implementedGenericType = property.PropertyType.Implements(genericTypeDefinition);
+                if (implementedGenericType is not null)
+                {
+                    dynamic? propertyValue = property.GetValue(o);
+                    if (propertyValue is not null)
+                        action(implementedGenericType, propertyValue);
                 }
             }
         }
+    }
 
-        private static Type? Implements(this Type type, Type genericTypeDefinition)
-        {
-            if (!genericTypeDefinition.IsInterface)
-                throw new ArgumentException("Currently working only for interface types");
-            if (type.IsInterface && type.IsGenericType && type.GetGenericTypeDefinition() == genericTypeDefinition)
-                return type;
-            foreach (var i in type.GetInterfaces())
-                if (i.IsGenericType && i.GetGenericTypeDefinition() == genericTypeDefinition)
-                    return i;
-            return null;
-        }
+    private static Type? Implements(this Type type, Type genericTypeDefinition)
+    {
+        if (!genericTypeDefinition.IsInterface)
+            throw new ArgumentException("Currently working only for interface types");
+        if (type.IsInterface && type.IsGenericType && type.GetGenericTypeDefinition() == genericTypeDefinition)
+            return type;
+        foreach (var i in type.GetInterfaces())
+            if (i.IsGenericType && i.GetGenericTypeDefinition() == genericTypeDefinition)
+                return i;
+        return null;
     }
 }

--- a/src/RaceDirector/Pipeline/Telemetry/TelemetryReaderNode.cs
+++ b/src/RaceDirector/Pipeline/Telemetry/TelemetryReaderNode.cs
@@ -6,35 +6,34 @@ using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using RaceDirector.Pipeline.Utils;
 
-namespace RaceDirector.Pipeline.Telemetry
+namespace RaceDirector.Pipeline.Telemetry;
+
+public sealed class TelemetryReaderNode : INode, IDisposable
 {
-    public sealed class TelemetryReaderNode : INode, IDisposable
+    public IObservable<V0.IGameTelemetry> GameTelemetryObservable => _subject.SelectManyUntilNext(rg => _createObservable(rg));
+
+    public IObserver<IRunningGame> RunningGameObserver => _subject;
+
+    private readonly Subject<IRunningGame> _subject;
+    private Func<IRunningGame, IObservable<V0.IGameTelemetry>> _createObservable;
+
+    public TelemetryReaderNode(IEnumerable<ITelemetryObservableFactory> telemetryObservableFactories)
     {
-        public IObservable<V0.IGameTelemetry> GameTelemetryObservable => _subject.SelectManyUntilNext(rg => _createObservable(rg));
+        _createObservable = telemetryObservableSelector(telemetryObservableFactories);
+        _subject = new Subject<IRunningGame>();
+    }
 
-        public IObserver<IRunningGame> RunningGameObserver => _subject;
+    private Func<IRunningGame, IObservable<V0.IGameTelemetry>> telemetryObservableSelector(IEnumerable<ITelemetryObservableFactory> telemetryObservableFactories)
+    {
+        return runningGame =>
+            telemetryObservableFactories
+                .FirstOrDefault(tsf => tsf.GameName.Equals(runningGame.Name))
+                ?.CreateTelemetryObservable()
+            ?? Observable.Empty<V0.IGameTelemetry>();
+    }
 
-        private readonly Subject<IRunningGame> _subject;
-        private Func<IRunningGame, IObservable<V0.IGameTelemetry>> _createObservable;
-
-        public TelemetryReaderNode(IEnumerable<ITelemetryObservableFactory> telemetryObservableFactories)
-        {
-            _createObservable = telemetryObservableSelector(telemetryObservableFactories);
-            _subject = new Subject<IRunningGame>();
-        }
-
-        private Func<IRunningGame, IObservable<V0.IGameTelemetry>> telemetryObservableSelector(IEnumerable<ITelemetryObservableFactory> telemetryObservableFactories)
-        {
-            return runningGame =>
-                telemetryObservableFactories
-                    .FirstOrDefault(tsf => tsf.GameName.Equals(runningGame.Name))
-                    ?.CreateTelemetryObservable()
-                    ?? Observable.Empty<V0.IGameTelemetry>();
-        }
-
-        public void Dispose()
-        {
-            _subject.Dispose();
-        }
+    public void Dispose()
+    {
+        _subject.Dispose();
     }
 }

--- a/src/RaceDirector/Pipeline/Utils/MemoryMappedFileReader.cs
+++ b/src/RaceDirector/Pipeline/Utils/MemoryMappedFileReader.cs
@@ -4,51 +4,50 @@ using System.IO.MemoryMappedFiles;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 
-namespace RaceDirector.Pipeline.Utils
+namespace RaceDirector.Pipeline.Utils;
+
+/// <summary>
+/// Utility class to reads a struct from a memory mapped file.
+/// </summary>
+[SupportedOSPlatform("windows")]
+public class MemoryMappedFileReader<T> : IDisposable where T : struct
 {
-    /// <summary>
-    /// Utility class to reads a struct from a memory mapped file.
-    /// </summary>
-    [SupportedOSPlatform("windows")]
-    public class MemoryMappedFileReader<T> : IDisposable where T : struct
+    private const long SharedMemoryBegin = 0;
+    private const long SharedMemoryEnd = 0;
+
+    private readonly string _path;
+
+    private MemoryMappedFile? _mmFile;
+
+    public MemoryMappedFileReader(string path)
     {
-        private const long SharedMemoryBegin = 0;
-        private const long SharedMemoryEnd = 0;
+        _path = path;
+    }
 
-        private readonly string _path;
+    /// <summary>
+    /// Reads a struct from the memory mapped file at the provided path.
+    /// Tries to open it on first access until it succeeds.
+    /// </summary>
+    /// <exception cref="FileNotFoundException">When opening the file. See <see cref="MemoryMappedFile.OpenExisting"/>.</exception>
+    /// <exception cref="UnauthorizedAccessException">When accessing the opened file. See <see cref="MemoryMappedFile.CreateViewStream"/>.</exception>
+    /// <exception cref="IOException">When reading from the shared memory. See <see cref="BinaryReader.ReadBytes"/>.</exception>
+    /// <remarks>
+    /// Not thread safe
+    /// </remarks>
+    public T Read()
+    {
+        if (_mmFile == null)
+            _mmFile = MemoryMappedFile.OpenExisting(_path, MemoryMappedFileRights.Read);
 
-        private MemoryMappedFile? _mmFile;
-
-        public MemoryMappedFileReader(string path)
+        using (var viewStream = _mmFile.CreateViewStream(SharedMemoryBegin, SharedMemoryEnd, MemoryMappedFileAccess.Read))
         {
-            _path = path;
+            var safeHandle = viewStream.SafeMemoryMappedViewHandle;
+            return Marshal.PtrToStructure<T>(safeHandle.DangerousGetHandle());
         }
+    }
 
-        /// <summary>
-        /// Reads a struct from the memory mapped file at the provided path.
-        /// Tries to open it on first access until it succeeds.
-        /// </summary>
-        /// <exception cref="FileNotFoundException">When opening the file. See <see cref="MemoryMappedFile.OpenExisting"/>.</exception>
-        /// <exception cref="UnauthorizedAccessException">When accessing the opened file. See <see cref="MemoryMappedFile.CreateViewStream"/>.</exception>
-        /// <exception cref="IOException">When reading from the shared memory. See <see cref="BinaryReader.ReadBytes"/>.</exception>
-        /// <remarks>
-        /// Not thread safe
-        /// </remarks>
-        public T Read()
-        {
-            if (_mmFile == null)
-                _mmFile = MemoryMappedFile.OpenExisting(_path, MemoryMappedFileRights.Read);
-
-            using (var viewStream = _mmFile.CreateViewStream(SharedMemoryBegin, SharedMemoryEnd, MemoryMappedFileAccess.Read))
-            {
-                var safeHandle = viewStream.SafeMemoryMappedViewHandle;
-                return Marshal.PtrToStructure<T>(safeHandle.DangerousGetHandle());
-            }
-        }
-
-        public void Dispose()
-        {
-            _mmFile?.Dispose();
-        }
+    public void Dispose()
+    {
+        _mmFile?.Dispose();
     }
 }

--- a/src/RaceDirector/Pipeline/Utils/ObserverExtensions.cs
+++ b/src/RaceDirector/Pipeline/Utils/ObserverExtensions.cs
@@ -1,23 +1,22 @@
 ﻿using System;
 using System.Reactive.Linq;
 
-namespace RaceDirector.Pipeline.Utils
-{
-    public static class ObserverExtensions
-    {
+namespace RaceDirector.Pipeline.Utils;
 
-        /// <summary>
-        /// Like <see cref="M:SelectMany"/> but the selector terminates when the source emits an element.
-        /// </summary>
-        /// <param name="source">TODO</param>
-        /// <param name="selector">TODO</param>
-        /// <typeparam name="TSource">TODO</typeparam>
-        /// <typeparam name="TResult">TODO</typeparam>
-        /// <returns>TODO</returns>
-        public static IObservable<TResult> SelectManyUntilNext<TSource, TResult>(this IObservable<TSource> source,
-            Func<TSource, IObservable<TResult>> selector)
-        {
-            return source.SelectMany(s => selector(s).TakeUntil(source));
-        }
+public static class ObserverExtensions
+{
+
+    /// <summary>
+    /// Like <see cref="M:SelectMany"/> but the selector terminates when the source emits an element.
+    /// </summary>
+    /// <param name="source">TODO</param>
+    /// <param name="selector">TODO</param>
+    /// <typeparam name="TSource">TODO</typeparam>
+    /// <typeparam name="TResult">TODO</typeparam>
+    /// <returns>TODO</returns>
+    public static IObservable<TResult> SelectManyUntilNext<TSource, TResult>(this IObservable<TSource> source,
+        Func<TSource, IObservable<TResult>> selector)
+    {
+        return source.SelectMany(s => selector(s).TakeUntil(source));
     }
 }

--- a/src/RaceDirector/Plugin/DefaultPlugin.cs
+++ b/src/RaceDirector/Plugin/DefaultPlugin.cs
@@ -4,34 +4,33 @@ using RaceDirector.Pipeline.GameMonitor;
 using RaceDirector.Pipeline.Telemetry;
 using System.Runtime.Versioning;
 
-namespace RaceDirector.Plugin
+namespace RaceDirector.Plugin;
+
+[SupportedOSPlatform("windows")]
+public class DefaultPlugin : PluginBase<DefaultPlugin.Configuration>
 {
     [SupportedOSPlatform("windows")]
-    public class DefaultPlugin : PluginBase<DefaultPlugin.Configuration>
+    protected override void Init(Configuration configuration, IServiceCollection services)
     {
-        [SupportedOSPlatform("windows")]
-        protected override void Init(Configuration configuration, IServiceCollection services)
-        {
-            services
-                .AddSingletonWithInterfaces<Pipeline.Games.R3E.Game>()
-                .AddSingletonWithInterfaces(_ => configuration.Games.R3E)
-                .AddSingletonWithInterfaces<Pipeline.Games.ACC.Game>()
-                .AddSingletonWithInterfaces(_ => configuration.Games.Acc)
-                .AddTransientWithInterfaces<ProcessMonitorNode>()
-                .AddSingletonWithInterfaces(_ => configuration.ProcessMonitor)
-                .AddTransientWithInterfaces<TelemetryReaderNode>();
-        }
+        services
+            .AddSingletonWithInterfaces<Pipeline.Games.R3E.Game>()
+            .AddSingletonWithInterfaces(_ => configuration.Games.R3E)
+            .AddSingletonWithInterfaces<Pipeline.Games.ACC.Game>()
+            .AddSingletonWithInterfaces(_ => configuration.Games.Acc)
+            .AddTransientWithInterfaces<ProcessMonitorNode>()
+            .AddSingletonWithInterfaces(_ => configuration.ProcessMonitor)
+            .AddTransientWithInterfaces<TelemetryReaderNode>();
+    }
 
-        public class Configuration
-        {
-            public ProcessMonitorNode.Config ProcessMonitor { get; set; } = null!;
-            public GamesConfiguration Games { get; set; } = null!;
-        }
+    public class Configuration
+    {
+        public ProcessMonitorNode.Config ProcessMonitor { get; set; } = null!;
+        public GamesConfiguration Games { get; set; } = null!;
+    }
 
-        public class GamesConfiguration
-        {
-            public Pipeline.Games.ACC.Game.Config Acc { get; set; } = null!;
-            public Pipeline.Games.R3E.Game.Config R3E { get; set; } = null!;
-        }
+    public class GamesConfiguration
+    {
+        public Pipeline.Games.ACC.Game.Config Acc { get; set; } = null!;
+        public Pipeline.Games.R3E.Game.Config R3E { get; set; } = null!;
     }
 }

--- a/src/RaceDirector/Plugin/PluginLoader.cs
+++ b/src/RaceDirector/Plugin/PluginLoader.cs
@@ -1,16 +1,15 @@
 ﻿using System.Collections.Generic;
 using System.Runtime.Versioning;
 
-namespace RaceDirector.Plugin
+namespace RaceDirector.Plugin;
+
+[SupportedOSPlatform("windows")]
+public static class PluginLoader
 {
     [SupportedOSPlatform("windows")]
-    public static class PluginLoader
-    {
-        [SupportedOSPlatform("windows")]
 
-        public static IEnumerable<IPlugin> InstantiatePlugins()
-        {
-            return new IPlugin[] { new DefaultPlugin(), new HUD.Plugin() };
-        }
+    public static IEnumerable<IPlugin> InstantiatePlugins()
+    {
+        return new IPlugin[] { new DefaultPlugin(), new HUD.Plugin() };
     }
 }

--- a/src/RaceDirector/Program.cs
+++ b/src/RaceDirector/Program.cs
@@ -6,34 +6,33 @@ using System.Runtime.Versioning;
 using Microsoft.Extensions.Configuration;
 using RaceDirector.Config;
 
-namespace RaceDirector
+namespace RaceDirector;
+
+[SupportedOSPlatform("windows")]
+static class Program
 {
-    [SupportedOSPlatform("windows")]
-    static class Program
+    static void Main(string[] args)
     {
-        static void Main(string[] args)
-        {
-            var plugins = PluginLoader.InstantiatePlugins();
+        var plugins = PluginLoader.InstantiatePlugins();
 
-            var host = Host.CreateDefaultBuilder(args)
-                .ConfigureAppConfiguration((_, configurationBuilder) =>
-                {
-                    IPAddressConverter.Register();
-                    configurationBuilder
-                        .AddJsonFile("appsettings.json", optional: false, reloadOnChange: false)
-                        .AddCommandLine(args);
-                })
-                .ConfigureServices((context, services) =>
-                {
-                    foreach (var p in plugins)
-                        p.Init(context.Configuration, services);
-                })
-                .Build();
+        var host = Host.CreateDefaultBuilder(args)
+            .ConfigureAppConfiguration((_, configurationBuilder) =>
+            {
+                IPAddressConverter.Register();
+                configurationBuilder
+                    .AddJsonFile("appsettings.json", optional: false, reloadOnChange: false)
+                    .AddCommandLine(args);
+            })
+            .ConfigureServices((context, services) =>
+            {
+                foreach (var p in plugins)
+                    p.Init(context.Configuration, services);
+            })
+            .Build();
 
-            var nodes = host.Services.GetServices<INode>();
-            PipelineBuilder.LinkNodes(nodes);
+        var nodes = host.Services.GetServices<INode>();
+        PipelineBuilder.LinkNodes(nodes);
 
-            host.WaitForShutdown();
-        }
+        host.WaitForShutdown();
     }
 }

--- a/tests/Plugins/HUD.Tests/Base/IntegrationTestBase.cs
+++ b/tests/Plugins/HUD.Tests/Base/IntegrationTestBase.cs
@@ -2,33 +2,32 @@
 using System.Threading;
 using Xunit.Categories;
 
-namespace HUD.Tests.Base
+namespace HUD.Tests.Base;
+
+[IntegrationTest]
+public abstract class IntegrationTestBase
 {
-    [IntegrationTest]
-    public abstract class IntegrationTestBase
+    protected static TimeSpan Timeout { get => TimeSpan.FromMilliseconds(500); }
+    protected static TimeSpan PollingInterval { get => TimeSpan.FromMilliseconds(50); }
+
+    protected void Eventually(Action f) => Eventually(f, "Not satisfied within timeout");
+
+    protected void Eventually(Action f, string message)
     {
-        protected static TimeSpan Timeout { get => TimeSpan.FromMilliseconds(500); }
-        protected static TimeSpan PollingInterval { get => TimeSpan.FromMilliseconds(50); }
-
-        protected void Eventually(Action f) => Eventually(f, "Not satisfied within timeout");
-
-        protected void Eventually(Action f, string message)
+        var end = DateTime.Now.Add(Timeout);
+        while (true)
         {
-            var end = DateTime.Now.Add(Timeout);
-            while (true)
+            try
             {
-                try
-                {
-                    f();
-                    break;
-                }
-                catch (Exception e)
-                {
-                    if (DateTime.Now > end)
-                        throw new TimeoutException(message, e);
-                    else
-                        Thread.Sleep(PollingInterval);
-                }
+                f();
+                break;
+            }
+            catch (Exception e)
+            {
+                if (DateTime.Now > end)
+                    throw new TimeoutException(message, e);
+                else
+                    Thread.Sleep(PollingInterval);
             }
         }
     }

--- a/tests/Plugins/HUD.Tests/Pipeline/DashboardServerTest.cs
+++ b/tests/Plugins/HUD.Tests/Pipeline/DashboardServerTest.cs
@@ -10,38 +10,37 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
-namespace HUD.Tests.Pipeline
+namespace HUD.Tests.Pipeline;
+
+public class DashboardServerTest : IntegrationTestBase
 {
-    public class DashboardServerTest : IntegrationTestBase
+    private static Bogus.Faker<GameTelemetry> gtFaker = new AutoFaker<GameTelemetry>()
+        .Configure(b => b
+            .WithBinder<MoqBinder>()
+            // For some reason AutoBogus/Moq can't generate IDistance or IFraction<IDistance>
+            .WithOverride(agoc => IDistance.FromM(agoc.Faker.Random.Int()))
+            .WithOverride(agoc => DistanceFraction.Of(agoc.Generate<IDistance>(), agoc.Faker.Random.Double()))
+        );
+
+    [Fact]
+    public void ServesR3ETelemetryEndpoint()
     {
-        private static Bogus.Faker<GameTelemetry> gtFaker = new AutoFaker<GameTelemetry>()
-            .Configure(b => b
-                .WithBinder<MoqBinder>()
-                // For some reason AutoBogus/Moq can't generate IDistance or IFraction<IDistance>
-                .WithOverride(agoc => IDistance.FromM(agoc.Faker.Random.Int()))
-                .WithOverride(agoc => DistanceFraction.Of(agoc.Generate<IDistance>(), agoc.Faker.Random.Double()))
-            );
+        using var server = new DashboardServer(new DashboardServer.Config { Address = IPAddress.Any, Port = _serverPort }, TestLogger);
+        Assert.True(server.Start(), "Server did not start");
+        using var client = new JsonWsClient(Timeout, _serverPort, "/r3e");
+        var telemetry = gtFaker.Generate();
 
-        [Fact]
-        public void ServesR3ETelemetryEndpoint()
-        {
-            using var server = new DashboardServer(new DashboardServer.Config { Address = IPAddress.Any, Port = _serverPort }, TestLogger);
-            Assert.True(server.Start(), "Server did not start");
-            using var client = new JsonWsClient(Timeout, _serverPort, "/r3e");
-            var telemetry = gtFaker.Generate();
-
-            Assert.True(client.ConnectAndWait(), "Client could not connect");
-            server.Multicast(telemetry);
-            var message = client.NextJson();
-            Assert.Equal(System.Text.Json.JsonValueKind.Number, message.Path("VersionMajor").ValueKind);
-            Assert.Equal(System.Text.Json.JsonValueKind.Number, message.Path("VersionMinor").ValueKind);
-        }
-
-        #region Test setup
-
-        private readonly int _serverPort = Tcp.FreePort();
-        private static readonly ILogger<DashboardServer> TestLogger = NullLogger<DashboardServer>.Instance;
-
-        #endregion
+        Assert.True(client.ConnectAndWait(), "Client could not connect");
+        server.Multicast(telemetry);
+        var message = client.NextJson();
+        Assert.Equal(System.Text.Json.JsonValueKind.Number, message.Path("VersionMajor").ValueKind);
+        Assert.Equal(System.Text.Json.JsonValueKind.Number, message.Path("VersionMinor").ValueKind);
     }
+
+    #region Test setup
+
+    private readonly int _serverPort = Tcp.FreePort();
+    private static readonly ILogger<DashboardServer> TestLogger = NullLogger<DashboardServer>.Instance;
+
+    #endregion
 }

--- a/tests/Plugins/HUD.Tests/Pipeline/MultiEndpointWsServerTest.cs
+++ b/tests/Plugins/HUD.Tests/Pipeline/MultiEndpointWsServerTest.cs
@@ -10,44 +10,43 @@ using System.Text;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
-namespace HUD.Tests.Pipeline
+namespace HUD.Tests.Pipeline;
+
+public class MultiEndpointWsServerTest : IntegrationTestBase
 {
-    public class MultiEndpointWsServerTest : IntegrationTestBase
+    [Fact]
+    public void FailsConnectionIfNoMatchingEndpoint()
     {
-        [Fact]
-        public void FailsConnectionIfNoMatchingEndpoint()
-        {
-            WithServerClient(Enumerable.Empty<IEndpoint<int>>(), "GET", (server, client) => {
-                Assert.False(client.ConnectAndWait());
-            });
-        }
-
-        [Fact]
-        public void ReceivedBroadcastForMatchingEndpoint()
-        {
-            var endpoints = new [] {
-                new Endpoint<int>(Endpoint.PathMatcher("/foo"), _ => Encoding.UTF8.GetBytes("")),
-                new Endpoint<int>(Endpoint.PathMatcher("/bar"), i => Encoding.UTF8.GetBytes(i.ToString())),
-                new Endpoint<int>(Endpoint.PathMatcher("/baz"), _ => Encoding.UTF8.GetBytes("24")),
-            };
-            WithServerClient(endpoints, "/bar", (server, client) =>
-            {
-                Assert.True(client.ConnectAndWait(), "Client could not connect");
-                server.Multicast(42);
-                Assert.Equal("42", client.NextString());
-            });
-        }
-
-        #region Test setup
-
-        private void WithServerClient<T>(IEnumerable<IEndpoint<T>> endpoints, string path, Action<IWsServer<T>, JsonWsClient> action)
-        {
-            var serverPort = Tcp.FreePort();
-            using var server = new MultiEndpointWsServer<T>(IPAddress.Any, serverPort, endpoints, NullLogger.Instance);
-            server.Start();
-            using var client = new JsonWsClient(Timeout, serverPort, path);
-            action(server, client);
-        }
-        #endregion
+        WithServerClient(Enumerable.Empty<IEndpoint<int>>(), "GET", (server, client) => {
+            Assert.False(client.ConnectAndWait());
+        });
     }
+
+    [Fact]
+    public void ReceivedBroadcastForMatchingEndpoint()
+    {
+        var endpoints = new [] {
+            new Endpoint<int>(Endpoint.PathMatcher("/foo"), _ => Encoding.UTF8.GetBytes("")),
+            new Endpoint<int>(Endpoint.PathMatcher("/bar"), i => Encoding.UTF8.GetBytes(i.ToString())),
+            new Endpoint<int>(Endpoint.PathMatcher("/baz"), _ => Encoding.UTF8.GetBytes("24")),
+        };
+        WithServerClient(endpoints, "/bar", (server, client) =>
+        {
+            Assert.True(client.ConnectAndWait(), "Client could not connect");
+            server.Multicast(42);
+            Assert.Equal("42", client.NextString());
+        });
+    }
+
+    #region Test setup
+
+    private void WithServerClient<T>(IEnumerable<IEndpoint<T>> endpoints, string path, Action<IWsServer<T>, JsonWsClient> action)
+    {
+        var serverPort = Tcp.FreePort();
+        using var server = new MultiEndpointWsServer<T>(IPAddress.Any, serverPort, endpoints, NullLogger.Instance);
+        server.Start();
+        using var client = new JsonWsClient(Timeout, serverPort, path);
+        action(server, client);
+    }
+    #endregion
 }

--- a/tests/Plugins/HUD.Tests/Pipeline/WebSocketNodeBaseTest.cs
+++ b/tests/Plugins/HUD.Tests/Pipeline/WebSocketNodeBaseTest.cs
@@ -6,66 +6,65 @@ using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
-namespace HUD.Tests.Pipeline
+namespace HUD.Tests.Pipeline;
+
+public class WebSocketNodeBaseTest : IntegrationTestBase
 {
-    public class WebSocketNodeBaseTest : IntegrationTestBase
+    [Fact]
+    public void ServerIsStartedWhenTriggered()
     {
-        [Fact]
-        public void ServerIsStartedWhenTriggered()
-        {
-            _webSocketNode.PostTrigger(true);
-            foreach (var sm in _serverMocks)
-                Eventually(() => sm.Verify(s => s.Start()), "Server wasn't started");
-        }
-
-        [Fact]
-        public void ServerIsStoppedWhenTriggered()
-        {
-            _webSocketNode.PostTrigger(false);
-            foreach (var sm in _serverMocks)
-                Eventually(() => sm.Verify(s => s.Stop(), "Server didn't stop"));
-        }
-
-        [Fact]
-        public void DataIsBroadcastedWhenReceived()
-        {
-            _webSocketNode.PostData(2);
-            foreach (var sm in _serverMocks)
-                Eventually(() => sm.Verify(s => s.Multicast(2)), "Data wasn't broadcasted");
-        }
-
-        #region Test setup
-
-        private readonly IEnumerable<Mock<IWsServer<int>>> _serverMocks;
-        private readonly TestWebSocketNode _webSocketNode;
-
-        public WebSocketNodeBaseTest()
-        {
-            _serverMocks = Enumerable.Range(1, 3).Select(_ => new Mock<IWsServer<int>>()).ToArray();
-            var mockedServers = _serverMocks.Select(m => m.Object).ToArray();
-            _webSocketNode = new TestWebSocketNode(mockedServers);
-        }
-
-        private class TestWebSocketNode : WebSocketNodeBase<bool, int>
-        {
-            public TestWebSocketNode(params IWsServer<int>[] servers) : base(servers) { }
-
-            protected override bool ServerShouldRun(bool trigger)
-            {
-                return trigger;
-            }
-
-            public void PostTrigger(bool trigger)
-            {
-                TriggerObserver.OnNext(trigger);
-            }
-
-            public void PostData(int data)
-            {
-                DataObserver.OnNext(data);
-            }
-        }
-
-        #endregion
+        _webSocketNode.PostTrigger(true);
+        foreach (var sm in _serverMocks)
+            Eventually(() => sm.Verify(s => s.Start()), "Server wasn't started");
     }
+
+    [Fact]
+    public void ServerIsStoppedWhenTriggered()
+    {
+        _webSocketNode.PostTrigger(false);
+        foreach (var sm in _serverMocks)
+            Eventually(() => sm.Verify(s => s.Stop(), "Server didn't stop"));
+    }
+
+    [Fact]
+    public void DataIsBroadcastedWhenReceived()
+    {
+        _webSocketNode.PostData(2);
+        foreach (var sm in _serverMocks)
+            Eventually(() => sm.Verify(s => s.Multicast(2)), "Data wasn't broadcasted");
+    }
+
+    #region Test setup
+
+    private readonly IEnumerable<Mock<IWsServer<int>>> _serverMocks;
+    private readonly TestWebSocketNode _webSocketNode;
+
+    public WebSocketNodeBaseTest()
+    {
+        _serverMocks = Enumerable.Range(1, 3).Select(_ => new Mock<IWsServer<int>>()).ToArray();
+        var mockedServers = _serverMocks.Select(m => m.Object).ToArray();
+        _webSocketNode = new TestWebSocketNode(mockedServers);
+    }
+
+    private class TestWebSocketNode : WebSocketNodeBase<bool, int>
+    {
+        public TestWebSocketNode(params IWsServer<int>[] servers) : base(servers) { }
+
+        protected override bool ServerShouldRun(bool trigger)
+        {
+            return trigger;
+        }
+
+        public void PostTrigger(bool trigger)
+        {
+            TriggerObserver.OnNext(trigger);
+        }
+
+        public void PostData(int data)
+        {
+            DataObserver.OnNext(data);
+        }
+    }
+
+    #endregion
 }

--- a/tests/Plugins/HUD.Tests/TestUtils/JsonExtensions.cs
+++ b/tests/Plugins/HUD.Tests/TestUtils/JsonExtensions.cs
@@ -2,35 +2,34 @@
 using System.Text;
 using System.Text.Json;
 
-namespace HUD.Tests.TestUtils
+namespace HUD.Tests.TestUtils;
+
+static class JsonExtensions
 {
-    static class JsonExtensions
+    public static JsonElement Path(this JsonDocument jsonDoc, params string[] segments)
     {
-        public static JsonElement Path(this JsonDocument jsonDoc, params string[] segments)
-        {
-            return jsonDoc.RootElement.Path(segments);
-        }
+        return jsonDoc.RootElement.Path(segments);
+    }
 
-        public static JsonElement Path(this JsonElement jsonEl, params string[] segments)
+    public static JsonElement Path(this JsonElement jsonEl, params string[] segments)
+    {
+        foreach (var s in segments)
         {
-            foreach (var s in segments)
-            {
-                jsonEl = jsonEl.GetProperty(s);
-            }
-            return jsonEl;
+            jsonEl = jsonEl.GetProperty(s);
         }
+        return jsonEl;
+    }
 
-        public static bool IsNull(this JsonElement jsonEl)
-        {
-            return jsonEl.ValueKind == JsonValueKind.Null;
-        }
+    public static bool IsNull(this JsonElement jsonEl)
+    {
+        return jsonEl.ValueKind == JsonValueKind.Null;
+    }
 
-        public static String? GetBase64String(this JsonElement jsonEl)
-        {
-            var encodedName = jsonEl.GetString();
-            if (encodedName == null)
-                return null;
-            return Encoding.UTF8.GetString(Convert.FromBase64String(encodedName));
-        }
+    public static String? GetBase64String(this JsonElement jsonEl)
+    {
+        var encodedName = jsonEl.GetString();
+        if (encodedName == null)
+            return null;
+        return Encoding.UTF8.GetString(Convert.FromBase64String(encodedName));
     }
 }

--- a/tests/Plugins/HUD.Tests/TestUtils/Tcp.cs
+++ b/tests/Plugins/HUD.Tests/TestUtils/Tcp.cs
@@ -1,17 +1,16 @@
 ﻿using System.Net;
 using System.Net.Sockets;
 
-namespace HUD.Tests.TestUtils
+namespace HUD.Tests.TestUtils;
+
+internal static class Tcp
 {
-    internal static class Tcp
+    public static int FreePort()
     {
-        public static int FreePort()
-        {
-            TcpListener l = new TcpListener(IPAddress.Loopback, 0);
-            l.Start();
-            int port = ((IPEndPoint)l.LocalEndpoint).Port;
-            l.Stop();
-            return port;
-        }
+        TcpListener l = new TcpListener(IPAddress.Loopback, 0);
+        l.Start();
+        int port = ((IPEndPoint)l.LocalEndpoint).Port;
+        l.Stop();
+        return port;
     }
 }

--- a/tests/RaceDirector.Tests.Ext.Process/Program.cs
+++ b/tests/RaceDirector.Tests.Ext.Process/Program.cs
@@ -2,16 +2,15 @@
 using System.Diagnostics;
 using System.Threading;
 
-namespace RaceDirector.Tests.Ext.Process
+namespace RaceDirector.Tests.Ext.Process;
+
+class Program
 {
-    class Program
+    static void Main(string[] args)
     {
-        static void Main(string[] args)
-        {
-            var timeToWait = args[1];
-            Debug.Write("Waiting " + timeToWait + " seconds... ");
-            Thread.Sleep(TimeSpan.FromSeconds(Convert.ToInt32(timeToWait)));
-            Debug.WriteLine("DONE!");
-        }
+        var timeToWait = args[1];
+        Debug.Write("Waiting " + timeToWait + " seconds... ");
+        Thread.Sleep(TimeSpan.FromSeconds(Convert.ToInt32(timeToWait)));
+        Debug.WriteLine("DONE!");
     }
 }

--- a/tests/RaceDirector.Tests/Config/IPAddressConverterTest.cs
+++ b/tests/RaceDirector.Tests/Config/IPAddressConverterTest.cs
@@ -12,8 +12,8 @@ namespace RaceDirector.Tests.Config;
 [UnitTest]
 public class IPAddressConverterTest
 {
-    private TypeConverter _converter = new IPAddressConverter();
-    private IPAddress _ip = IPAddress.Any;
+    private readonly TypeConverter _converter = new IPAddressConverter();
+    private readonly IPAddress _ip = IPAddress.Any;
 
     [Fact]
     public void CanConvertIPs()
@@ -52,7 +52,7 @@ public class IPAddressConverterTest
 
     private class TestConfig
     {
-        public IPAddress? Ip { get; set; }
+        public IPAddress Ip { get; set; } = null!;
 
         public IConfigurationRoot AsIConfiguration()
         {

--- a/tests/RaceDirector.Tests/Pipeline/DecoupledAcceptanceTest.cs
+++ b/tests/RaceDirector.Tests/Pipeline/DecoupledAcceptanceTest.cs
@@ -16,132 +16,131 @@ using RaceDirector.Tests.Pipeline.Utils;
 using Xunit;
 using Xunit.Categories;
 
-namespace RaceDirector.Tests.Pipeline
+namespace RaceDirector.Tests.Pipeline;
+
+[IntegrationTest]
+public class DecoupledAcceptanceTest : ReactiveTest
 {
-    [IntegrationTest]
-    public class DecoupledAcceptanceTest : ReactiveTest
+    [Fact]
+    public void Lifecycle()
     {
-        [Fact]
-        public void Lifecycle()
+        var testScheduler = new TestScheduler();
+
+        var fakeGame = new FakeGame(callCount =>
+            testScheduler.CreateColdObservable(FakeTelemetry(3, 50, callCount, 0.01))
+        );
+
+        var fakeProcesses = new Dictionary<long, string[]>
         {
-            var testScheduler = new TestScheduler();
+            [20] = fakeGame.GameProcessNames,
+            [40] = Array.Empty<string>(),
+            [60] = fakeGame.GameProcessNames,
+            [80] = Array.Empty<string>()
+        };
 
-            var fakeGame = new FakeGame(callCount =>
-                testScheduler.CreateColdObservable(FakeTelemetry(3, 50, callCount, 0.01))
-            );
+        var wsServerMock = new Mock<IWsServer<IGameTelemetry>>();
 
-            var fakeProcesses = new Dictionary<long, string[]>
+        PipelineBuilder.LinkNodes(new INode[]
             {
-                [20] = fakeGame.GameProcessNames,
-                [40] = Array.Empty<string>(),
-                [60] = fakeGame.GameProcessNames,
-                [80] = Array.Empty<string>()
-            };
+                new FakeProcessMonitorNode(new[] {fakeGame}, fakeProcesses, testScheduler),
+                new TelemetryReaderNode(new[] {fakeGame}),
+                new WebSocketTelemetryNode(new[] {wsServerMock.Object})
+            }
+        );
 
-            var wsServerMock = new Mock<IWsServer<IGameTelemetry>>();
+        testScheduler.AdvanceTo(20);
+        wsServerMock.Verify(s => s.Start());
+        wsServerMock.VerifyNoOtherCalls();
+        wsServerMock.Reset();
 
-            PipelineBuilder.LinkNodes(new INode[]
-                {
-                    new FakeProcessMonitorNode(new[] {fakeGame}, fakeProcesses, testScheduler),
-                    new TelemetryReaderNode(new[] {fakeGame}),
-                    new WebSocketTelemetryNode(new[] {wsServerMock.Object})
-                }
-            );
+        testScheduler.AdvanceTo(39);
+        wsServerMock.Verify(s => s.Multicast(Match.Create<IGameTelemetry>(_ => true)), Times.Exactly(20 / 3));
+        wsServerMock.Reset();
 
-            testScheduler.AdvanceTo(20);
-            wsServerMock.Verify(s => s.Start());
-            wsServerMock.VerifyNoOtherCalls();
-            wsServerMock.Reset();
+        testScheduler.AdvanceTo(40);
+        wsServerMock.Verify(s => s.Stop());
+        testScheduler.AdvanceTo(59);
+        wsServerMock.VerifyNoOtherCalls();
+        wsServerMock.Reset();
 
-            testScheduler.AdvanceTo(39);
-            wsServerMock.Verify(s => s.Multicast(Match.Create<IGameTelemetry>(_ => true)), Times.Exactly(20 / 3));
-            wsServerMock.Reset();
+        testScheduler.AdvanceTo(60);
+        wsServerMock.Verify(s => s.Start());
+        wsServerMock.VerifyNoOtherCalls();
+        wsServerMock.Reset();
 
-            testScheduler.AdvanceTo(40);
-            wsServerMock.Verify(s => s.Stop());
-            testScheduler.AdvanceTo(59);
-            wsServerMock.VerifyNoOtherCalls();
-            wsServerMock.Reset();
+        testScheduler.AdvanceTo(79);
+        wsServerMock.Verify(s => s.Multicast(Match.Create<IGameTelemetry>(_ => true)), Times.Exactly(20 / 3));
+        wsServerMock.Reset();
 
-            testScheduler.AdvanceTo(60);
-            wsServerMock.Verify(s => s.Start());
-            wsServerMock.VerifyNoOtherCalls();
-            wsServerMock.Reset();
-
-            testScheduler.AdvanceTo(79);
-            wsServerMock.Verify(s => s.Multicast(Match.Create<IGameTelemetry>(_ => true)), Times.Exactly(20 / 3));
-            wsServerMock.Reset();
-
-            testScheduler.AdvanceTo(80);
-            wsServerMock.Verify(s => s.Stop());
-            testScheduler.AdvanceTo(99);
-            wsServerMock.VerifyNoOtherCalls();
-            wsServerMock.Reset();
-        }
-
-        private Recorded<Notification<TestGameTelemetry>>[] FakeTelemetry(long tickIncrements, long maxTick,
-            double baseValue, double valueIncrements)
-        {
-            var maxGenerated = 10;
-            return Enumerable.Range(1, maxGenerated)
-                .TakeWhile(i => i * tickIncrements <= maxTick)
-                .Select(i => OnNext(i * tickIncrements, new TestGameTelemetry(baseValue + i * valueIncrements)))
-                .ToArray();
-        }
+        testScheduler.AdvanceTo(80);
+        wsServerMock.Verify(s => s.Stop());
+        testScheduler.AdvanceTo(99);
+        wsServerMock.VerifyNoOtherCalls();
+        wsServerMock.Reset();
     }
 
-    internal record FakeGame(Func<double, IObservable<IGameTelemetry>> CreateTelemetryObservableF) : IGame
+    private Recorded<Notification<TestGameTelemetry>>[] FakeTelemetry(long tickIncrements, long maxTick,
+        double baseValue, double valueIncrements)
     {
-        private int _createTelemetryCallCounter;
+        var maxGenerated = 10;
+        return Enumerable.Range(1, maxGenerated)
+            .TakeWhile(i => i * tickIncrements <= maxTick)
+            .Select(i => OnNext(i * tickIncrements, new TestGameTelemetry(baseValue + i * valueIncrements)))
+            .ToArray();
+    }
+}
 
-        public string GameName => "TestGame";
+internal record FakeGame(Func<double, IObservable<IGameTelemetry>> CreateTelemetryObservableF) : IGame
+{
+    private int _createTelemetryCallCounter;
 
-        public string[] GameProcessNames => new[] {"TestProcess.exe"};
+    public string GameName => "TestGame";
 
-        public IObservable<IGameTelemetry> CreateTelemetryObservable()
-        {
-            double callCount = Interlocked.Add(ref _createTelemetryCallCounter, 1);
-            return CreateTelemetryObservableF(callCount);
-        }
+    public string[] GameProcessNames => new[] {"TestProcess.exe"};
+
+    public IObservable<IGameTelemetry> CreateTelemetryObservable()
+    {
+        double callCount = Interlocked.Add(ref _createTelemetryCallCounter, 1);
+        return CreateTelemetryObservableF(callCount);
+    }
+}
+
+public record TestGameTelemetry(double Identifier) : IGameTelemetry
+{
+    public GameState GameState => GameState.Menu;
+
+    public bool? UsingVR => null;
+
+    public IEvent? Event => null;
+
+    public ISession? Session => null;
+
+    public IVehicle[] Vehicles => Array.Empty<IVehicle>();
+
+    public IFocusedVehicle? FocusedVehicle => null;
+
+    public IPlayer? Player => null;
+}
+
+public class FakeProcessMonitorNode : TestProcessMonitorNode
+{
+    private readonly Dictionary<long, string[]> _simulatedProcessNames;
+
+    public FakeProcessMonitorNode(IEnumerable<IGameProcessInfo> gameProcessInfos,
+        Dictionary<long, string[]> simulatedProcessNames, TestScheduler testScheduler) :
+        base(new Config { PollingInterval = TimeSpan.FromTicks(1) }, gameProcessInfos, testScheduler)
+    {
+        _simulatedProcessNames = simulatedProcessNames;
     }
 
-    public record TestGameTelemetry(double Identifier) : IGameTelemetry
+    protected override IEnumerable<string> CurrentProcessNames()
     {
-        public GameState GameState => GameState.Menu;
-
-        public bool? UsingVR => null;
-
-        public IEvent? Event => null;
-
-        public ISession? Session => null;
-
-        public IVehicle[] Vehicles => Array.Empty<IVehicle>();
-
-        public IFocusedVehicle? FocusedVehicle => null;
-
-        public IPlayer? Player => null;
-    }
-
-    public class FakeProcessMonitorNode : TestProcessMonitorNode
-    {
-        private readonly Dictionary<long, string[]> _simulatedProcessNames;
-
-        public FakeProcessMonitorNode(IEnumerable<IGameProcessInfo> gameProcessInfos,
-            Dictionary<long, string[]> simulatedProcessNames, TestScheduler testScheduler) :
-            base(new Config { PollingInterval = TimeSpan.FromTicks(1) }, gameProcessInfos, testScheduler)
-        {
-            _simulatedProcessNames = simulatedProcessNames;
-        }
-
-        protected override IEnumerable<string> CurrentProcessNames()
-        {
-            var currentTicks = TestScheduler.Now.Ticks;
-            var maxPastTickInSimulation = _simulatedProcessNames
-                .Select(p => p.Key)
-                .Where(t => t <= currentTicks)
-                .DefaultIfEmpty(-1)
-                .Max();
-            return _simulatedProcessNames.GetValueOrDefault(maxPastTickInSimulation, Array.Empty<string>());
-        }
+        var currentTicks = TestScheduler.Now.Ticks;
+        var maxPastTickInSimulation = _simulatedProcessNames
+            .Select(p => p.Key)
+            .Where(t => t <= currentTicks)
+            .DefaultIfEmpty(-1)
+            .Max();
+        return _simulatedProcessNames.GetValueOrDefault(maxPastTickInSimulation, Array.Empty<string>());
     }
 }

--- a/tests/RaceDirector.Tests/Pipeline/GameMonitor/KeepOneTest.cs
+++ b/tests/RaceDirector.Tests/Pipeline/GameMonitor/KeepOneTest.cs
@@ -4,122 +4,121 @@ using RaceDirector.Pipeline.GameMonitor;
 using System.Linq;
 using Xunit.Categories;
 
-namespace RaceDirector.Tests.Pipeline.GameMonitor
+namespace RaceDirector.Tests.Pipeline.GameMonitor;
+
+[UnitTest]
+public class KeepOneTest
 {
-    [UnitTest]
-    public class KeepOneTest
+    private static readonly string?[] NoOutput = Array.Empty<string?>();
+    private static readonly string?[] NullOutput = { null };
+
+    [Fact]
+    public void EmitsWhenFirstMatched()
     {
-        private static readonly string?[] NoOutput = Array.Empty<string?>();
-        private static readonly string?[] NullOutput = { null };
+        AssertIOKeepOneAB(
+            input: new[]
+            {
+                new[] { "a" }
+            },
+            expectedOutput: new[]
+            {
+                new[] { "a" }
+            }
+        );
+    }
 
-        [Fact]
-        public void EmitsWhenFirstMatched()
-        {
-            AssertIOKeepOneAB(
-                input: new[]
-                {
-                    new[] { "a" }
-                },
-                expectedOutput: new[]
-                {
-                    new[] { "a" }
-                }
-            );
-        }
+    [Fact]
+    public void DoesntEmitIfFirstNotMatched()
+    {
+        AssertIOKeepOneAB(
+            input: new[]
+            {
+                new[] { "x" },
+            },
+            expectedOutput: new[]
+            {
+                NoOutput
+            }
+        );
+    }
 
-        [Fact]
-        public void DoesntEmitIfFirstNotMatched()
-        {
-            AssertIOKeepOneAB(
-                input: new[]
-                {
-                    new[] { "x" },
-                },
-                expectedOutput: new[]
-                {
-                    NoOutput
-                }
-            );
-        }
+    [Fact]
+    public void EmitsWhenMatchAfterNoMatch()
+    {
+        AssertIOKeepOneAB(
+            input: new[]
+            {
+                new[] { "x" },
+                new[] { "a" },
+            },
+            expectedOutput: new[]
+            {
+                NoOutput,
+                new[] { "a" }
+            }
+        );
+    }
 
-        [Fact]
-        public void EmitsWhenMatchAfterNoMatch()
-        {
-            AssertIOKeepOneAB(
-                input: new[]
-                {
-                    new[] { "x" },
-                    new[] { "a" },
-                },
-                expectedOutput: new[]
-                {
-                    NoOutput,
-                    new[] { "a" }
-                }
-            );
-        }
+    [Fact]
+    public void EmitsTheFirstWhenMultipleFound()
+    {
+        AssertIOKeepOneAB(
+            input: new[]
+            {
+                new[] { "x", "b", "a" }
+            },
+            expectedOutput: new[]
+            {
+                new[] { "b" }
+            }
+        );
+    }
 
-        [Fact]
-        public void EmitsTheFirstWhenMultipleFound()
-        {
-            AssertIOKeepOneAB(
-                input: new[]
-                {
-                    new[] { "x", "b", "a" }
-                },
-                expectedOutput: new[]
-                {
-                    new[] { "b" }
-                }
-            );
-        }
+    [Fact]
+    public void EmitsWhenNotMatchingAnymore()
+    {
+        AssertIOKeepOneAB(
+            input: new[]
+            {
+                new[] { "a" },
+                new[] { "x" }
+            },
+            expectedOutput: new[]
+            {
+                new[] { "a" },
+                NullOutput
+            }
+        );
+    }
 
-        [Fact]
-        public void EmitsWhenNotMatchingAnymore()
-        {
-            AssertIOKeepOneAB(
-                input: new[]
-                {
-                    new[] { "a" },
-                    new[] { "x" }
-                },
-                expectedOutput: new[]
-                {
-                    new[] { "a" },
-                    NullOutput
-                }
-            );
-        }
+    [Fact]
+    public void DoesntEmitWhenPreviousMatchPresent()
+    {
+        AssertIOKeepOneAB(
+            input: new[]
+            {
+                new[] { "a" },
+                new[] { "a", "b" },
+                new[] { "b" }
+            },
+            expectedOutput: new[]
+            {
+                new[] { "a" },
+                NoOutput,
+                new[] { "b" }
+            }
+        );
+    }
 
-        [Fact]
-        public void DoesntEmitWhenPreviousMatchPresent()
-        {
-            AssertIOKeepOneAB(
-                input: new[]
-                {
-                    new[] { "a" },
-                    new[] { "a", "b" },
-                    new[] { "b" }
-                },
-                expectedOutput: new[]
-                {
-                    new[] { "a" },
-                    NoOutput,
-                    new[] { "b" }
-                }
-            );
-        }
+    private void AssertIOKeepOneAB(string[][] input, string?[][] expectedOutput)
+    {
+        AssertIO(new[] { "a", "b" }, input, expectedOutput);
+    }
 
-        private void AssertIOKeepOneAB(string[][] input, string?[][] expectedOutput)
-        {
-             AssertIO(new[] { "a", "b" }, input, expectedOutput);
-        }
-
-        private void AssertIO(string[] config, string[][] input, string?[][] expectedOutput)
-        {
-            var kos = new KeepOne<string>(config);
-            var output = input.AsEnumerable().Select(kos.Call).ToArray();
-            Assert.Equal(expectedOutput.AsEnumerable(), output);
-        }
+    private void AssertIO(string[] config, string[][] input, string?[][] expectedOutput)
+    {
+        var kos = new KeepOne<string>(config);
+        var output = input.AsEnumerable().Select(kos.Call).ToArray();
+        Assert.Equal(expectedOutput.AsEnumerable(), output);
     }
 }

--- a/tests/RaceDirector.Tests/Pipeline/GameMonitor/ProcessMonitorNodeTest.cs
+++ b/tests/RaceDirector.Tests/Pipeline/GameMonitor/ProcessMonitorNodeTest.cs
@@ -7,54 +7,53 @@ using RaceDirector.Tests.Pipeline.Utils;
 using Xunit;
 using Xunit.Categories;
 
-namespace RaceDirector.Tests.Pipeline.GameMonitor
+namespace RaceDirector.Tests.Pipeline.GameMonitor;
+
+[IntegrationTest, LocalTest]
+public class ProcessMonitorNodeTest
 {
-    [IntegrationTest, LocalTest]
-    public class ProcessMonitorNodeTest
+    private static readonly TimeSpan PollingInterval = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan Timeout = PollingInterval * 3;
+
+    private static readonly string GameName = "TestGame";
+    private static readonly string ProcessName = "RaceDirector.Tests.Ext.Process";
+    private static readonly string ProcessArgs = Timeout.Multiply(3).Seconds.ToString();
+
+    [Fact]
+    public void OutputGameNameWhenProcessRunning()
     {
-        private static readonly TimeSpan PollingInterval = TimeSpan.FromSeconds(1);
-        private static readonly TimeSpan Timeout = PollingInterval * 3;
-
-        private static readonly string GameName = "TestGame";
-        private static readonly string ProcessName = "RaceDirector.Tests.Ext.Process";
-        private static readonly string ProcessArgs = Timeout.Multiply(3).Seconds.ToString();
-
-        [Fact]
-        public void OutputGameNameWhenProcessRunning()
+        var testScheduler = new TestScheduler();
+        var gameProcessInfos = new[]
         {
-            var testScheduler = new TestScheduler();
-            var gameProcessInfos = new[]
-            {
-                new GameProcessInfo(GameName, new[] {ProcessName})
-            };
-            var config = new ProcessMonitorNode.Config { PollingInterval = PollingInterval };
-            var processMonitorNode = new TestProcessMonitorNode(config, gameProcessInfos, testScheduler);
-            var observer = testScheduler.CreateObserver<RunningGame>();
-            processMonitorNode.RunningGameObservable.Subscribe(observer);
-            using (new RunningProcess(ProcessName, ProcessArgs))
-            {
-                testScheduler.AdvanceTo(PollingInterval.Ticks);
-                var first = Assert.Single(observer.ReceivedValues());
-                Assert.Equal(GameName, first.Name);
-            }
-
-            testScheduler.AdvanceBy(PollingInterval.Ticks);
-            var second = Assert.Single(observer.ReceivedValues().Skip(1));
-            Assert.Null(second.Name);
+            new GameProcessInfo(GameName, new[] {ProcessName})
+        };
+        var config = new ProcessMonitorNode.Config { PollingInterval = PollingInterval };
+        var processMonitorNode = new TestProcessMonitorNode(config, gameProcessInfos, testScheduler);
+        var observer = testScheduler.CreateObserver<RunningGame>();
+        processMonitorNode.RunningGameObservable.Subscribe(observer);
+        using (new RunningProcess(ProcessName, ProcessArgs))
+        {
+            testScheduler.AdvanceTo(PollingInterval.Ticks);
+            var first = Assert.Single(observer.ReceivedValues());
+            Assert.Equal(GameName, first.Name);
         }
 
-        private record GameProcessInfo(string GameName, string[] GameProcessNames) : IGameProcessInfo;
+        testScheduler.AdvanceBy(PollingInterval.Ticks);
+        var second = Assert.Single(observer.ReceivedValues().Skip(1));
+        Assert.Null(second.Name);
+    }
 
-        private record RunningProcess(string Name, string Args) : IDisposable
+    private record GameProcessInfo(string GameName, string[] GameProcessNames) : IGameProcessInfo;
+
+    private record RunningProcess(string Name, string Args) : IDisposable
+    {
+        private const string DotExe = ".exe";
+
+        private readonly Process _process = Process.Start(Name + DotExe, Args);
+
+        public void Dispose()
         {
-            private const string DotExe = ".exe";
-
-            private readonly Process _process = Process.Start(Name + DotExe, Args);
-
-            public void Dispose()
-            {
-                _process.Kill();
-            }
+            _process.Kill();
         }
     }
 }

--- a/tests/RaceDirector.Tests/Pipeline/GameMonitor/TestProcessMonitorNode.cs
+++ b/tests/RaceDirector.Tests/Pipeline/GameMonitor/TestProcessMonitorNode.cs
@@ -5,22 +5,21 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Reactive.Testing;
 using RaceDirector.Pipeline.GameMonitor;
 
-namespace RaceDirector.Tests.Pipeline.Utils
+namespace RaceDirector.Tests.Pipeline.Utils;
+
+/// <summary>
+/// ProcessMonitorNode that runs on a test scheduler and null logger.
+/// </summary>
+public class TestProcessMonitorNode : ProcessMonitorNode
 {
-    /// <summary>
-    /// ProcessMonitorNode that runs on a test scheduler and null logger.
-    /// </summary>
-    public class TestProcessMonitorNode : ProcessMonitorNode
+    protected readonly TestScheduler TestScheduler;
+
+    public TestProcessMonitorNode(Config config, IEnumerable<IGameProcessInfo> gameProcessInfos, TestScheduler testScheduler) :
+        base(NullLogger<ProcessMonitorNode>.Instance, config, gameProcessInfos)
     {
-        protected readonly TestScheduler TestScheduler;
-
-        public TestProcessMonitorNode(Config config, IEnumerable<IGameProcessInfo> gameProcessInfos, TestScheduler testScheduler) :
-            base(NullLogger<ProcessMonitorNode>.Instance, config, gameProcessInfos)
-        {
-            TestScheduler = testScheduler;
-        }
-
-        protected override IObservable<long> ObservableInterval(Config config) =>
-            Observable.Interval(config.PollingInterval, TestScheduler);
+        TestScheduler = testScheduler;
     }
+
+    protected override IObservable<long> ObservableInterval(Config config) =>
+        Observable.Interval(config.PollingInterval, TestScheduler);
 }

--- a/tests/RaceDirector.Tests/Pipeline/Games/R3E/TelemetryTest.cs
+++ b/tests/RaceDirector.Tests/Pipeline/Games/R3E/TelemetryTest.cs
@@ -3,40 +3,39 @@ using RaceDirector.Pipeline.Telemetry;
 using Xunit;
 using Xunit.Categories;
 
-namespace RaceDirector.Tests.Pipeline.Games.R3E
+namespace RaceDirector.Tests.Pipeline.Games.R3E;
+
+[UnitTest]
+public class TelemetryTest
 {
-    [UnitTest]
-    public class TelemetryTest
+    [Fact]
+    public void StatefulAid__NotAvailable()
     {
-        [Fact]
-        public void StatefulAid__NotAvailable()
-        {
-            var sa = StatefulAid.Generic();
+        var sa = StatefulAid.Generic();
 
-            Assert.Null(sa.Update(-1));
-        }
+        Assert.Null(sa.Update(-1));
+    }
 
-        [Fact]
-        public void StatefulAid__Inactive()
-        {
-            var sa = StatefulAid.Generic();
+    [Fact]
+    public void StatefulAid__Inactive()
+    {
+        var sa = StatefulAid.Generic();
 
-            Assert.Equal(new Aid(0, false), sa.Update(0));
-            Assert.Equal(new Aid(1, false), sa.Update(1));
-            Assert.Equal(new Aid(2, false), sa.Update(2));
-            Assert.Equal(new Aid(3, false), sa.Update(3));
-            Assert.Equal(new Aid(4, false), sa.Update(4));
-        }
+        Assert.Equal(new Aid(0, false), sa.Update(0));
+        Assert.Equal(new Aid(1, false), sa.Update(1));
+        Assert.Equal(new Aid(2, false), sa.Update(2));
+        Assert.Equal(new Aid(3, false), sa.Update(3));
+        Assert.Equal(new Aid(4, false), sa.Update(4));
+    }
 
-        [Fact]
-        public void StatefulAid__Active()
-        {
-            var sa = StatefulAid.Generic();
+    [Fact]
+    public void StatefulAid__Active()
+    {
+        var sa = StatefulAid.Generic();
 
-            Assert.Null(sa.Update(5));
-            Assert.Equal(new Aid(2, false), sa.Update(2));
-            Assert.Equal(new Aid(2, true), sa.Update(5));
-            Assert.Equal(new Aid(3, false), sa.Update(3));
-        }
+        Assert.Null(sa.Update(5));
+        Assert.Equal(new Aid(2, false), sa.Update(2));
+        Assert.Equal(new Aid(2, true), sa.Update(5));
+        Assert.Equal(new Aid(3, false), sa.Update(3));
     }
 }

--- a/tests/RaceDirector.Tests/Pipeline/PipelineBuilderTest.cs
+++ b/tests/RaceDirector.Tests/Pipeline/PipelineBuilderTest.cs
@@ -9,111 +9,110 @@ using System.Linq;
 using RaceDirector.Tests.Pipeline.Utils;
 using System.Reactive;
 
-namespace RaceDirector.Tests.Pipeline
+namespace RaceDirector.Tests.Pipeline;
+
+[IntegrationTest]
+public class PipelineBuilderTest
 {
-    [IntegrationTest]
-    public class PipelineBuilderTest
+    private static int EventsTimestamp = 42;
+
+    private readonly TestScheduler testScheduler = new ();
+
+    [Fact]
+    public void LinksObservableToObserversOfAssignableType()
     {
-        private static int EventsTimestamp = 42;
+        var message = new V1<int, long>(1, 2);
 
-        private readonly TestScheduler testScheduler = new ();
+        var observableNodeV1 = new OneObservableNode<V1<int, long>>(testScheduler, message);
+        var observerNodeIV0 = new OneObserverNode<IV0<int>>(testScheduler);
+        var observerNodeIV1 = new OneObserverNode<IV1<int, long>>(testScheduler);
 
-        [Fact]
-        public void LinksObservableToObserversOfAssignableType()
-        {
-            var message = new V1<int, long>(1, 2);
+        LinkAndRun(testScheduler, observableNodeV1, observerNodeIV0, observerNodeIV1);
 
-            var observableNodeV1 = new OneObservableNode<V1<int, long>>(testScheduler, message);
-            var observerNodeIV0 = new OneObserverNode<IV0<int>>(testScheduler);
-            var observerNodeIV1 = new OneObserverNode<IV1<int, long>>(testScheduler);
-
-            LinkAndRun(testScheduler, observableNodeV1, observerNodeIV0, observerNodeIV1);
-
-            Assert.Equal(message, observerNodeIV0.T1.ReceivedValues().First());
-            Assert.Equal(message, observerNodeIV1.T1.ReceivedValues().First());
-        }
-
-        [Fact]
-        public void DoesNotLinkObservableWhenObserverTypeUnssignable()
-        {
-            var observableNode = new OneObservableNode<int>(testScheduler, 42);
-            var observerNode = new TwoObserversNode<int, string>(testScheduler);
-
-            LinkAndRun(testScheduler, observableNode, observerNode);
-
-            Assert.Equal(42, observerNode.T1.ReceivedValues().First());
-            Assert.Empty(observerNode.T2.ReceivedValues());
-        }
-
-        [Fact]
-        public void SupportsBlocksThatAreBothObservableAndObserver()
-        {
-            var observableNode = new OneObservableNode<int>(testScheduler, 42);
-            var transformationNode = new TransformationNode<int, string>(i => i.ToString());
-            var observerNode = new OneObserverNode<string>(testScheduler);
-
-            LinkAndRun(testScheduler, observableNode, transformationNode, observerNode);
-
-            Assert.Equal("42", observerNode.T1.ReceivedValues().First());
-        }
-
-        #region Test setup
-
-        public interface IV0<T1> { T1 P1 { get; } }
-        public interface IV1<T1, T2> : IV0<T1> { T2 P2 { get; } }
-
-        public record V1<T1, T2>(T1 P1, T2 P2) : IV1<T1, T2>;
-
-        public class OneObservableNode<T> : INode
-        {
-            public ITestableObservable<T> S1  { get; private set; }
-
-            public OneObservableNode(TestScheduler testScheduler, params T[] messages)
-            {
-                var recordedNotifications = messages.Select(m =>
-                    new Recorded<Notification<T>>(EventsTimestamp, Notification.CreateOnNext(m))
-                ).ToArray();
-                S1 = testScheduler.CreateHotObservable<T>(recordedNotifications);
-            }
-        }
-
-        public class OneObserverNode<T> : INode
-        {
-            public ITestableObserver<T> T1 { get; private set; }
-
-            public OneObserverNode(TestScheduler testScheduler)
-            {
-                T1 = testScheduler.CreateObserver<T>();
-            }
-        }
-
-        public class TwoObserversNode<TI1, TI2> : OneObserverNode<TI1>
-        {
-            public ITestableObserver<TI2> T2 { get; private set; }
-
-            public TwoObserversNode(TestScheduler testScheduler) : base(testScheduler)
-            {
-                T2 = testScheduler.CreateObserver<TI2>();
-            }
-        }
-
-        public class TransformationNode<TI, TO> : INode
-        {
-            public ISubject<TI, TO> ObservableAndObserver { get; private set; }
-            
-            public TransformationNode(Func<TI, TO> f)
-            {
-                var subject = new Subject<TI>();
-                ObservableAndObserver = Subject.Create(subject, subject.Select(f));
-            }
-        }
-
-        private static void LinkAndRun(TestScheduler testScheduler, params INode[] nodes)
-        {
-            PipelineBuilder.LinkNodes(nodes);
-            testScheduler.AdvanceTo(EventsTimestamp);
-        }
-
-        #endregion
+        Assert.Equal(message, observerNodeIV0.T1.ReceivedValues().First());
+        Assert.Equal(message, observerNodeIV1.T1.ReceivedValues().First());
     }
+
+    [Fact]
+    public void DoesNotLinkObservableWhenObserverTypeUnssignable()
+    {
+        var observableNode = new OneObservableNode<int>(testScheduler, 42);
+        var observerNode = new TwoObserversNode<int, string>(testScheduler);
+
+        LinkAndRun(testScheduler, observableNode, observerNode);
+
+        Assert.Equal(42, observerNode.T1.ReceivedValues().First());
+        Assert.Empty(observerNode.T2.ReceivedValues());
+    }
+
+    [Fact]
+    public void SupportsBlocksThatAreBothObservableAndObserver()
+    {
+        var observableNode = new OneObservableNode<int>(testScheduler, 42);
+        var transformationNode = new TransformationNode<int, string>(i => i.ToString());
+        var observerNode = new OneObserverNode<string>(testScheduler);
+
+        LinkAndRun(testScheduler, observableNode, transformationNode, observerNode);
+
+        Assert.Equal("42", observerNode.T1.ReceivedValues().First());
+    }
+
+    #region Test setup
+
+    public interface IV0<T1> { T1 P1 { get; } }
+    public interface IV1<T1, T2> : IV0<T1> { T2 P2 { get; } }
+
+    public record V1<T1, T2>(T1 P1, T2 P2) : IV1<T1, T2>;
+
+    public class OneObservableNode<T> : INode
+    {
+        public ITestableObservable<T> S1  { get; private set; }
+
+        public OneObservableNode(TestScheduler testScheduler, params T[] messages)
+        {
+            var recordedNotifications = messages.Select(m =>
+                new Recorded<Notification<T>>(EventsTimestamp, Notification.CreateOnNext(m))
+            ).ToArray();
+            S1 = testScheduler.CreateHotObservable<T>(recordedNotifications);
+        }
+    }
+
+    public class OneObserverNode<T> : INode
+    {
+        public ITestableObserver<T> T1 { get; private set; }
+
+        public OneObserverNode(TestScheduler testScheduler)
+        {
+            T1 = testScheduler.CreateObserver<T>();
+        }
+    }
+
+    public class TwoObserversNode<TI1, TI2> : OneObserverNode<TI1>
+    {
+        public ITestableObserver<TI2> T2 { get; private set; }
+
+        public TwoObserversNode(TestScheduler testScheduler) : base(testScheduler)
+        {
+            T2 = testScheduler.CreateObserver<TI2>();
+        }
+    }
+
+    public class TransformationNode<TI, TO> : INode
+    {
+        public ISubject<TI, TO> ObservableAndObserver { get; private set; }
+            
+        public TransformationNode(Func<TI, TO> f)
+        {
+            var subject = new Subject<TI>();
+            ObservableAndObserver = Subject.Create(subject, subject.Select(f));
+        }
+    }
+
+    private static void LinkAndRun(TestScheduler testScheduler, params INode[] nodes)
+    {
+        PipelineBuilder.LinkNodes(nodes);
+        testScheduler.AdvanceTo(EventsTimestamp);
+    }
+
+    #endregion
 }

--- a/tests/RaceDirector.Tests/Pipeline/Telemetry/TelemetryReaderNodeTest.cs
+++ b/tests/RaceDirector.Tests/Pipeline/Telemetry/TelemetryReaderNodeTest.cs
@@ -10,62 +10,61 @@ using System.Reactive.Linq;
 using Xunit;
 using Xunit.Categories;
 
-namespace RaceDirector.Tests.Pipeline.Telemetry
+namespace RaceDirector.Tests.Pipeline.Telemetry;
+
+[IntegrationTest]
+public class TelemetryReaderNodeTest
 {
-    [IntegrationTest]
-    public class TelemetryReaderNodeTest
+    private static readonly TimeSpan Timeout = TimeSpan.FromMilliseconds(50);
+
+    private static readonly IGameTelemetry[] Telemetry = AutoFaker.Generate<IGameTelemetry>(3, b => b.WithBinder<MoqBinder>()).ToArray();
+
+    private TestScheduler _testScheduler;
+    private ITestableObserver<IGameTelemetry> _testObserver;
+
+    public TelemetryReaderNodeTest()
     {
-        private static readonly TimeSpan Timeout = TimeSpan.FromMilliseconds(50);
+        _testScheduler = new TestScheduler();
+        _testObserver = _testScheduler.CreateObserver<IGameTelemetry>();
+    }
 
-        private static readonly IGameTelemetry[] Telemetry = AutoFaker.Generate<IGameTelemetry>(3, b => b.WithBinder<MoqBinder>()).ToArray();
+    [Fact]
+    public void DoesNotEmitWhenGameNotMatching()
+    {
+        var trn = new TelemetryReaderNode(Array.Empty<ITelemetryObservableFactory>());
+        trn.GameTelemetryObservable.Subscribe(_testObserver);
 
-        private TestScheduler _testScheduler;
-        private ITestableObserver<IGameTelemetry> _testObserver;
+        trn.RunningGameObserver.OnNext(new RunningGame(null));
+        trn.RunningGameObserver.OnNext(new RunningGame("any"));
 
-        public TelemetryReaderNodeTest()
+        Assert.Empty(_testObserver.ReceivedValues());
+    }
+
+    [Fact]
+    public void SwitchesSourcesWhenGameChanges()
+    {
+        var trn = new TelemetryReaderNode(new ITelemetryObservableFactory[]
         {
-            _testScheduler = new TestScheduler();
-            _testObserver = _testScheduler.CreateObserver<IGameTelemetry>();
-        }
+            new TestTelemetryObservableFactory("a", Telemetry[0]),
+            new TestTelemetryObservableFactory("b", Telemetry[1], Telemetry[2])
+        });
+        trn.GameTelemetryObservable.Subscribe(_testObserver);
 
-        [Fact]
-        public void DoesNotEmitWhenGameNotMatching()
+        trn.RunningGameObserver.OnNext(new RunningGame("a"));
+        Assert.Equal(new[] { Telemetry[0] }, _testObserver.ReceivedValues());
+
+        trn.RunningGameObserver.OnNext(new RunningGame("b"));
+        Assert.Equal(new[] { Telemetry[0], Telemetry[1], Telemetry[2] }, _testObserver.ReceivedValues());
+
+        trn.RunningGameObserver.OnNext(new RunningGame("a"));
+        Assert.Equal(new[] { Telemetry[0], Telemetry[1], Telemetry[2], Telemetry[0] }, _testObserver.ReceivedValues());
+    }
+
+    private record TestTelemetryObservableFactory(string GameName, params IGameTelemetry[] Elements) : ITelemetryObservableFactory
+    {
+        public IObservable<IGameTelemetry> CreateTelemetryObservable()
         {
-            var trn = new TelemetryReaderNode(Array.Empty<ITelemetryObservableFactory>());
-            trn.GameTelemetryObservable.Subscribe(_testObserver);
-
-            trn.RunningGameObserver.OnNext(new RunningGame(null));
-            trn.RunningGameObserver.OnNext(new RunningGame("any"));
-
-            Assert.Empty(_testObserver.ReceivedValues());
-        }
-
-        [Fact]
-        public void SwitchesSourcesWhenGameChanges()
-        {
-            var trn = new TelemetryReaderNode(new ITelemetryObservableFactory[]
-            {
-                    new TestTelemetryObservableFactory("a", Telemetry[0]),
-                    new TestTelemetryObservableFactory("b", Telemetry[1], Telemetry[2])
-            });
-            trn.GameTelemetryObservable.Subscribe(_testObserver);
-
-            trn.RunningGameObserver.OnNext(new RunningGame("a"));
-            Assert.Equal(new[] { Telemetry[0] }, _testObserver.ReceivedValues());
-
-            trn.RunningGameObserver.OnNext(new RunningGame("b"));
-            Assert.Equal(new[] { Telemetry[0], Telemetry[1], Telemetry[2] }, _testObserver.ReceivedValues());
-
-            trn.RunningGameObserver.OnNext(new RunningGame("a"));
-            Assert.Equal(new[] { Telemetry[0], Telemetry[1], Telemetry[2], Telemetry[0] }, _testObserver.ReceivedValues());
-        }
-
-        private record TestTelemetryObservableFactory(string GameName, params IGameTelemetry[] Elements) : ITelemetryObservableFactory
-        {
-            public IObservable<IGameTelemetry> CreateTelemetryObservable()
-            {
-                return Elements.ToObservable();
-            }
+            return Elements.ToObservable();
         }
     }
 }

--- a/tests/RaceDirector.Tests/Pipeline/Utils/MemoryMappedFileReaderTest.cs
+++ b/tests/RaceDirector.Tests/Pipeline/Utils/MemoryMappedFileReaderTest.cs
@@ -8,78 +8,77 @@ using System.Runtime.Versioning;
 using Xunit;
 using Xunit.Categories;
 
-namespace RaceDirector.Tests.Pipeline.Utils
+namespace RaceDirector.Tests.Pipeline.Utils;
+
+[IntegrationTest]
+[SupportedOSPlatform("windows")]
+public class MemoryMappedFileReaderTest
 {
-    [IntegrationTest]
-    [SupportedOSPlatform("windows")]
-    public class MemoryMappedFileReaderTest
+    const string FileName = "$rdtest";
+
+    [Fact]
+    public void ThrowsExceptionOnReadWhenPathDoesntExist()
     {
-        const string FileName = "$rdtest";
+        using var reader = new MemoryMappedFileReader<TestStruct>(FileName);
+        Assert.Throws<FileNotFoundException>(() => reader.Read());
 
-        [Fact]
-        public void ThrowsExceptionOnReadWhenPathDoesntExist()
+        WithMMFile(FileName, new TestStruct(), (_, _) => {
+            // Verify that file is opened when available
+            reader.Read();
+        });
+    }
+
+    [Fact]
+    public void CanReadAMemoryMappedStruct()
+    {
+        var expectedStruct = new TestStruct()
         {
-            using var reader = new MemoryMappedFileReader<TestStruct>(FileName);
-            Assert.Throws<FileNotFoundException>(() => reader.Read());
-
-            WithMMFile(FileName, new TestStruct(), (_, _) => {
-                // Verify that file is opened when available
-                reader.Read();
-            });
-        }
-
-        [Fact]
-        public void CanReadAMemoryMappedStruct()
-        {
-            var expectedStruct = new TestStruct()
-            {
-                Field = SequentialByteArray(FieldSize)
-            };
+            Field = SequentialByteArray(FieldSize)
+        };
             
-            WithMMFile(FileName, expectedStruct, (path, writtenData) => {
-                using (var reader = new MemoryMappedFileReader<TestStruct>(path))
-                {
-                    Assert.Equal(writtenData.Field, reader.Read().Field);
-                    // Verify that the same data can be read more than once
-                    Assert.Equal(writtenData.Field, reader.Read().Field);
-                }
-            });
-        }
+        WithMMFile(FileName, expectedStruct, (path, writtenData) => {
+            using (var reader = new MemoryMappedFileReader<TestStruct>(path))
+            {
+                Assert.Equal(writtenData.Field, reader.Read().Field);
+                // Verify that the same data can be read more than once
+                Assert.Equal(writtenData.Field, reader.Read().Field);
+            }
+        });
+    }
 
-        private void WithMMFile<T>(string path, T data, Action<string, T> action) where T : struct
-        {
-            var structSize = Marshal.SizeOf(typeof(T));
-            Assert.Equal(FieldSize, structSize);
-            using var file = MemoryMappedFile.CreateNew(path, FieldSize);
-            using var viewStream = file.CreateViewStream();
-            var writer = new BinaryWriter(viewStream);
-            writer.Write(Serialize(data));
-            action(path, data);
-        }
+    private void WithMMFile<T>(string path, T data, Action<string, T> action) where T : struct
+    {
+        var structSize = Marshal.SizeOf(typeof(T));
+        Assert.Equal(FieldSize, structSize);
+        using var file = MemoryMappedFile.CreateNew(path, FieldSize);
+        using var viewStream = file.CreateViewStream();
+        var writer = new BinaryWriter(viewStream);
+        writer.Write(Serialize(data));
+        action(path, data);
+    }
 
-        private byte[] SequentialByteArray(int size)
-        {
-            return Enumerable.Range(1, size).Select(x => Convert.ToByte(x)).ToArray();
-        }
+    private byte[] SequentialByteArray(int size)
+    {
+        return Enumerable.Range(1, size).Select(x => Convert.ToByte(x)).ToArray();
+    }
 
-        private static byte[] Serialize<T>(T s) where T : struct
-        {
-            var size = Marshal.SizeOf(typeof(T));
-            var array = new byte[size];
-            var ptr = Marshal.AllocHGlobal(size);
-            Marshal.StructureToPtr(s, ptr, true);
-            Marshal.Copy(ptr, array, 0, size);
-            Marshal.FreeHGlobal(ptr);
-            return array;
-        }
+    private static byte[] Serialize<T>(T s) where T : struct
+    {
+        var size = Marshal.SizeOf(typeof(T));
+        var array = new byte[size];
+        var ptr = Marshal.AllocHGlobal(size);
+        Marshal.StructureToPtr(s, ptr, true);
+        Marshal.Copy(ptr, array, 0, size);
+        Marshal.FreeHGlobal(ptr);
+        return array;
+    }
 
-        const int FieldSize = 53;
+    const int FieldSize = 53;
 
-        [StructLayout(LayoutKind.Sequential, Pack = 1)]
-        internal struct TestStruct
-        {
-            [MarshalAs(UnmanagedType.ByValArray, SizeConst = FieldSize)]
-            public byte[] Field;
-        }
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    internal struct TestStruct
+    {
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = FieldSize)]
+        public byte[] Field;
     }
 }

--- a/tests/RaceDirector.Tests/Pipeline/Utils/ObserverExtensionsTest.cs
+++ b/tests/RaceDirector.Tests/Pipeline/Utils/ObserverExtensionsTest.cs
@@ -3,90 +3,89 @@ using RaceDirector.Pipeline.Utils;
 using Xunit;
 using Xunit.Categories;
 
-namespace RaceDirector.Tests.Pipeline.Utils
+namespace RaceDirector.Tests.Pipeline.Utils;
+
+[UnitTest]
+public class SelectManyUntilNextTest : ReactiveTest
 {
-    [UnitTest]
-    public class SelectManyUntilNextTest : ReactiveTest
+    [Fact]
+    public void SelectorsStopEmittingWhenSourceEmits()
     {
-        [Fact]
-        public void SelectorsStopEmittingWhenSourceEmits()
-        {
-            var scheduler = new TestScheduler();
-            const long sourceStart = Subscribed + 5;
-            const long sourceEmitOffset = 21;
-            const long sourceCompleteOffset = 100;
-            const long selectorCompleteOffset = 50;
+        var scheduler = new TestScheduler();
+        const long sourceStart = Subscribed + 5;
+        const long sourceEmitOffset = 21;
+        const long sourceCompleteOffset = 100;
+        const long selectorCompleteOffset = 50;
 
-            var source = scheduler.CreateHotObservable(
-                OnNext(sourceStart, 0),
-                OnNext(sourceStart + sourceEmitOffset, 1),
-                OnCompleted<int>(sourceStart + sourceCompleteOffset)
-            );
+        var source = scheduler.CreateHotObservable(
+            OnNext(sourceStart, 0),
+            OnNext(sourceStart + sourceEmitOffset, 1),
+            OnCompleted<int>(sourceStart + sourceCompleteOffset)
+        );
 
-            var res = scheduler.Start(() =>
-                source.SelectManyUntilNext(i => scheduler.CreateColdObservable(
-                    OnNext(10, 10*i+1),
-                    OnNext(20, 10*i+2),
-                    OnNext(30, 10*i+3),
-                    OnNext(40, 10*i+4),
-                    OnCompleted<int>(selectorCompleteOffset)
-                ))
-            );
+        var res = scheduler.Start(() =>
+            source.SelectManyUntilNext(i => scheduler.CreateColdObservable(
+                OnNext(10, 10*i+1),
+                OnNext(20, 10*i+2),
+                OnNext(30, 10*i+3),
+                OnNext(40, 10*i+4),
+                OnCompleted<int>(selectorCompleteOffset)
+            ))
+        );
             
-            source.Subscriptions.AssertEqual(
-                // Test
-                Subscribe(Subscribed, sourceStart + sourceCompleteOffset),
-                // SelectManyUntilNext
-                Subscribe(sourceStart, sourceStart + sourceEmitOffset),
-                Subscribe(sourceStart + sourceEmitOffset, sourceStart + sourceEmitOffset + selectorCompleteOffset)
-            );
+        source.Subscriptions.AssertEqual(
+            // Test
+            Subscribe(Subscribed, sourceStart + sourceCompleteOffset),
+            // SelectManyUntilNext
+            Subscribe(sourceStart, sourceStart + sourceEmitOffset),
+            Subscribe(sourceStart + sourceEmitOffset, sourceStart + sourceEmitOffset + selectorCompleteOffset)
+        );
             
-            res.Messages.AssertEqual(
-                OnNext(sourceStart + 10, 1),
-                OnNext(sourceStart + 20, 2),
-                OnNext(sourceStart + sourceEmitOffset + 10, 11),
-                OnNext(sourceStart + sourceEmitOffset + 20, 12),
-                OnNext(sourceStart + sourceEmitOffset + 30, 13),
-                OnNext(sourceStart + sourceEmitOffset + 40, 14),
-                OnCompleted<int>(sourceStart + sourceCompleteOffset)
-            );
-        }
+        res.Messages.AssertEqual(
+            OnNext(sourceStart + 10, 1),
+            OnNext(sourceStart + 20, 2),
+            OnNext(sourceStart + sourceEmitOffset + 10, 11),
+            OnNext(sourceStart + sourceEmitOffset + 20, 12),
+            OnNext(sourceStart + sourceEmitOffset + 30, 13),
+            OnNext(sourceStart + sourceEmitOffset + 40, 14),
+            OnCompleted<int>(sourceStart + sourceCompleteOffset)
+        );
+    }
         
-        [Fact]
-        public void SelectorKeepsEmittingWhenSourceCompletes()
-        {
-            var scheduler = new TestScheduler();
-            const long sourceStart = Subscribed + 5;
-            const long sourceCompleteOffset = 25;
-            const long selectorCompleteOffset = 50;
+    [Fact]
+    public void SelectorKeepsEmittingWhenSourceCompletes()
+    {
+        var scheduler = new TestScheduler();
+        const long sourceStart = Subscribed + 5;
+        const long sourceCompleteOffset = 25;
+        const long selectorCompleteOffset = 50;
 
-            var source = scheduler.CreateHotObservable(
-                OnNext(sourceStart, 0),
-                OnCompleted<int>(sourceStart + sourceCompleteOffset)
-            );
+        var source = scheduler.CreateHotObservable(
+            OnNext(sourceStart, 0),
+            OnCompleted<int>(sourceStart + sourceCompleteOffset)
+        );
 
-            var res = scheduler.Start(() =>
-                source.SelectManyUntilNext(_ => scheduler.CreateColdObservable(
-                    OnNext(10, 1),
-                    OnNext(20, 2),
-                    OnNext(30, 3),
-                    OnCompleted<int>(selectorCompleteOffset)
-                ))
-            );
+        var res = scheduler.Start(() =>
+            source.SelectManyUntilNext(_ => scheduler.CreateColdObservable(
+                OnNext(10, 1),
+                OnNext(20, 2),
+                OnNext(30, 3),
+                OnCompleted<int>(selectorCompleteOffset)
+            ))
+        );
             
-            source.Subscriptions.AssertEqual(
-                // Test
-                Subscribe(Subscribed, sourceStart + sourceCompleteOffset),
-                // SelectManyUntilNext
-                Subscribe(sourceStart, sourceStart + sourceCompleteOffset)
-            );
+        source.Subscriptions.AssertEqual(
+            // Test
+            Subscribe(Subscribed, sourceStart + sourceCompleteOffset),
+            // SelectManyUntilNext
+            Subscribe(sourceStart, sourceStart + sourceCompleteOffset)
+        );
             
-            res.Messages.AssertEqual(
-                OnNext(sourceStart + 10, 1),
-                OnNext(sourceStart + 20, 2),
-                OnNext(sourceStart + 30, 3),
-                OnCompleted<int>(sourceStart + selectorCompleteOffset)
-            );
-        }
+        res.Messages.AssertEqual(
+            OnNext(sourceStart + 10, 1),
+            OnNext(sourceStart + 20, 2),
+            OnNext(sourceStart + 30, 3),
+            OnCompleted<int>(sourceStart + selectorCompleteOffset)
+        );
     }
 }

--- a/tests/RaceDirector.Tests/Pipeline/Utils/TestableObserverExtensions.cs
+++ b/tests/RaceDirector.Tests/Pipeline/Utils/TestableObserverExtensions.cs
@@ -3,13 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reactive;
 
-namespace RaceDirector.Tests.Pipeline.Utils
+namespace RaceDirector.Tests.Pipeline.Utils;
+
+public static class TestableObserverExtensions
 {
-    public static class TestableObserverExtensions
-    {
-        public static IEnumerable<T> ReceivedValues<T>(this ITestableObserver<T> testableObserver) =>
-            testableObserver.Messages
-                .Where(n => n.Value.Kind == NotificationKind.OnNext)
-                .Select(n => n.Value.Value);
-    }
+    public static IEnumerable<T> ReceivedValues<T>(this ITestableObserver<T> testableObserver) =>
+        testableObserver.Messages
+            .Where(n => n.Value.Kind == NotificationKind.OnNext)
+            .Select(n => n.Value.Value);
 }


### PR DESCRIPTION
Namespaces can be made file-scoped after migrating to .NET 6.

Fixes also a test warning during the build.