### PR TITLE
Fix artefact publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: RaceDirector
-        path: src/RaceDirector/bin/Debug/net6.0/publish/**
+        path: src/RaceDirector/bin/Debug/net6.0-windows/publish/**
         if-no-files-found: error
     - if: ${{ github.ref == 'refs/heads/main' }}
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
After changes in #69, RaceDirector uses `net6.0-windows` instead of `net6.0` runtime.

[This](https://github.com/OpenSimTools/RaceDirector/actions/runs/3042038204/jobs/4899771633) is the resulting error:
```
Error: No files were found with the provided path: src/RaceDirector/bin/Debug/net6.0/publish/**. No artifacts will be uploaded.
```
